### PR TITLE
fix: modify replay_npz.py compatibility with MotionLoader API

### DIFF
--- a/scripts/replay_npz.py
+++ b/scripts/replay_npz.py
@@ -95,15 +95,14 @@ def run_simulator(sim: sim_utils.SimulationContext, scene: InteractiveScene):
     else:
         raise ValueError("Either --motion or --registry_name must be provided.")
 
-    # Load npz file to get body names and determine body_indexes
-    # For K1, we typically use Trunk as anchor body (index 0)
-    # body_indexes should be a list of indices corresponding to the bodies we want to use
-    # For replay, we only need the anchor body (Trunk), which is typically at index 0
-    body_indexes = [0]  # Default to index 0 for anchor body (Trunk)
+    # For K1, we typically use Trunk as anchor body.
+    track_body_names = ["Trunk"]
+    track_joint_names = robot.joint_names
     
     motion = MotionLoader(
         motion_file,
-        body_indexes,
+        track_body_names,
+        track_joint_names,
         tail_len=0,
         device=str(sim.device),
     )


### PR DESCRIPTION
# Description

`replay_npz.py` was not compatible with the current `MotionLoader` API, so the replay script could not run.

```
Traceback (most recent call last):
  File "/mnt/ssd2/booster/booster_train/scripts/replay_npz.py", line 148, in <module>
    main()
  File "/mnt/ssd2/booster/booster_train/scripts/replay_npz.py", line 143, in main
    run_simulator(sim, scene)
  File "/mnt/ssd2/booster/booster_train/scripts/replay_npz.py", line 104, in run_simulator
    motion = MotionLoader(
             ^^^^^^^^^^^^^
TypeError: MotionLoader.__init__() missing 1 required positional argument: 'track_joint_names'
```

This PR updates `replay_npz.py` to pass the tracked body names and joint names expected by `MotionLoader`.

# Test Performed

I verified locally that the reference motion can be replayed with:

```bash
python scripts/replay_npz.py \
  --motion ../booster_assets/motions/K1/k1_fight_001.npz \
  --device cuda:0
```
<img width="1920" height="1238" alt="image" src="https://github.com/user-attachments/assets/7b235a81-fde4-42f3-9e0a-7f967c40e7a9" />
