### PR TITLE
feat: add K1 locomotion training task

### DIFF
--- a/docs/k1-walk-isaaclab-design-differences.md
+++ b/docs/k1-walk-isaaclab-design-differences.md
@@ -1,0 +1,111 @@
+# K1 Walk vs Isaac Lab Biped Velocity Design Differences
+
+This note records the intentional behavior differences that should survive a
+style refactor of the K1 walk task toward the Isaac Lab G1/H1 velocity task
+style.
+
+Reference files:
+
+- K1 walk task:
+  `source/booster_train/booster_train/tasks/manager_based/locomotion/robots/k1/walk/env_cfg.py`
+- K1 walk observation helpers:
+  `source/booster_train/booster_train/tasks/manager_based/locomotion/mdp/observations.py`
+- K1 walk reward helpers:
+  `source/booster_train/booster_train/tasks/manager_based/locomotion/mdp/rewards.py`
+- Isaac Lab references, in the local checkout:
+  `../IsaacLab/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/`
+
+## Summary
+
+The K1 walk task should be treated as a K1-specific derivative of the Isaac Lab
+G1/H1 biped velocity tasks, not as a pure robot-asset swap.
+
+The main shared design is:
+
+- Manager-based Isaac Lab task structure.
+- Uniform base velocity command.
+- Joint position actions with default offsets.
+- RSL-RL PPO runner and standard PPO hyperparameter shape.
+- Biped velocity reward family:
+  `track_lin_vel_xy_yaw_frame_exp`, `track_ang_vel_z_world_exp`,
+  `feet_air_time_positive_biped`, `feet_slide`, `flat_orientation_l2`,
+  and `is_terminated`.
+
+The main K1-specific design is:
+
+- Deployment-compatible actor observation.
+- Actor does not observe base linear velocity.
+- Actor observation uses flattened temporal history.
+- Critic receives privileged simulation-only signals.
+- K1 joint order, K1 default pose, and K1 foot/contact body names are explicit.
+- Flat-ground, no-height-scan task by default.
+
+## Intentional Differences To Keep
+
+| Area | Isaac Lab G1/H1 velocity style | K1 walk design | Keep? | Reason |
+| --- | --- | --- | --- | --- |
+| Robot asset | `G1_MINIMAL_CFG` or `H1_MINIMAL_CFG` in robot-specific config | `BOOSTER_K1_CFG` injected in `FlatEnvCfg.__post_init__` | Yes | K1 needs its own articulation, initial base height, and default joint pose. |
+| Action joints | Usually broad regex such as `[".*"]`, then robot-specific penalties scope subsets | Explicit `K1_WALK_POLICY_JOINT_NAMES` with `preserve_order=True` | Yes | Policy action order must match K1 deploy/export order. |
+| Action scale | Isaac Lab base velocity config uses `0.5`; robot configs tune terms | K1 uses `K1_WALK_ACTION_SCALE = 0.25` | Yes | K1 actuator range and deploy policy expectations differ. |
+| Actor observation shape | Standard observation terms are listed independently and concatenated by the manager | One deploy-compatible observation term, flattened over history | Yes | This fixes the ONNX/deploy input contract. |
+| Actor base linear velocity | Often included in Isaac Lab policy observations, especially in base velocity tasks | Not included in the actor observation | Yes | Base linear velocity is not directly available on hardware with the same quality as simulation truth. |
+| Actor angular velocity | `base_ang_vel` observation term | `root_ang_vel_b` inside the deploy observation | Yes | Equivalent hardware-friendly IMU signal, just packaged differently. |
+| Actor gravity | `projected_gravity` observation term | `projected_gravity_b` inside the deploy observation | Yes | Hardware-friendly IMU-derived orientation signal. |
+| Actor command | `generated_commands(base_velocity)` | Command vector embedded in the deploy observation | Yes | Same command concept, different packaging. |
+| Actor joint state | `joint_pos_rel`, `joint_vel_rel` terms | Ordered K1 joint position error and scaled joint velocity | Yes | Preserves deploy order and deploy scaling. |
+| Actor history | Usually no flattened temporal history in the base Isaac Lab config | `history_length = 10`, `69 * 10 = 690` actor input | Yes | History helps the actor infer velocity/state without `base_lin_vel`. |
+| Observation corruption | Standard configs often enable noise/corruption per term | K1 deploy observation has corruption disabled | Yes, unless explicitly changed | Deployment-compatible observation should remain deterministic unless noise injection is deliberately reintroduced. |
+| Critic observation | Often same policy group or standard privileged setup depending on task | Privileged critic observation adds `root_lin_vel_b` and foot contacts | Yes | Asymmetric actor-critic: actor stays deployable, critic can use simulation truth during training. |
+| Terrain | Isaac Lab rough configs use terrain generator and height scanner; flat configs disable them | K1 walk is flat plane by default and has no height scanner | Yes for current K1 walk task | Current task is flat/deploy-focused. Add a separate rough variant if terrain perception is needed. |
+| Base contact body | `torso_link` or robot-specific base body | `Trunk` | Yes | K1 body naming. |
+| Foot body names | G1/H1 ankle/foot link regexes | `left_foot_link`, `right_foot_link` | Yes | K1 body naming and contact sensor scoping. |
+| Command heading | Isaac Lab base config supports heading commands; G1/H1 tune ranges | K1 disables heading commands | Yes | Current policy receives direct velocity command only. |
+| Command range | Isaac Lab robot configs tune x/y/yaw ranges per robot | K1 random command variant uses full x/y/yaw ranges; fixed-forward variant pins command | Yes, but review weights/ranges separately | These are task choices, not style choices. |
+| Reward helper names | Isaac Lab uses generic helpers where available | K1 adds `k1_*` helpers for torque, energy, contact force, stumble, and foot spacing | Yes where K1-specific behavior differs | These encode K1-specific reward semantics or deploy-specific scoping. |
+| PPO architecture | G1/H1 rough use `[512, 256, 128]` for actor/critic | K1 uses `[512, 256, 128]` | Yes | Same shape is acceptable; not a naming/style issue. |
+| PPO iterations | Isaac Lab examples use smaller iteration counts | K1 uses `max_iterations = 50000` | Yes, but tune experimentally | Training budget is a project choice. |
+| PPO empirical normalization | Isaac Lab G1/H1 examples use `False` | K1 walk uses `True` | Yes, unless training evidence says otherwise | This is a behavior change, not a style refactor item. |
+
+## Style-Only Refactor Candidates
+
+These can be changed to look more like Isaac Lab as long as behavior remains
+unchanged.
+
+| Current K1 walk item | Isaac Lab-style target | Constraint |
+| --- | --- | --- |
+| `K1WalkSceneCfg` | A name aligned with the environment class, such as `K1FlatSceneCfg` | Keep flat terrain and contact sensor behavior. |
+| `FlatEnvCfg` / `PlayFlatEnvCfg` | Names that mirror Isaac Lab's `*FlatEnvCfg` / `*FlatEnvCfg_PLAY` pattern | Keep registered Gym IDs stable or update registrations together. |
+| `JointPositionAction` or `joint_pos` naming | Prefer the Isaac Lab local convention used in the target file | Do not change action term order or `preserve_order=True`. |
+| Reward term names such as `joint_torques_l2` | Use Isaac Lab-style names when the helper semantics match | Do not rename K1-specific helpers into generic names if semantics differ. |
+| Grouped K1 constants near the top of the file | Keep constants, but group by role: action, observation, body names, default pose | Do not change joint order. |
+| Repeated `SceneEntityCfg` blocks | Extract local constants only if it improves clarity | Keep explicit scoping and `preserve_order` where required. |
+| `IdealFlatForward*` and `IdealFlatCommandRandom*` variants | Move or name them as debug/check variants | Avoid mixing debug variants with the main deploy task behavior. |
+
+## Extra Or Suspicious Items To Review Before Refactor
+
+These are not necessarily wrong, but they are not clearly required by the
+Isaac Lab-to-K1 design difference alone.
+
+| Item | Why review it |
+| --- | --- |
+| `K1_WALK_LEG_JOINT_NAMES` | Defined but currently unused. Remove it or use it in a scoped reward/event if needed. |
+| `IdealFlatForward*` and `IdealFlatCommandRandom*` classes | Useful for checks, but they make the main task file noisy. Consider moving debug variants or documenting them. |
+| `clip_actions = None` in PPO config | This may be intentional for export/deploy compatibility. Confirm before changing. |
+| `empirical_normalization = True` | Behavior differs from Isaac Lab G1/H1 examples. Keep if training depends on it; otherwise test both. |
+| Removed Isaac Lab license headers in locomotion files | If substantial code remains derived from Isaac Lab, attribution and license handling should be reviewed. |
+
+## Refactor Rule
+
+When aligning K1 walk code style to Isaac Lab:
+
+1. Preserve all rows marked `Keep? = Yes` unless a separate behavior-change
+   decision is made.
+2. Prefer Isaac Lab naming and class layout only where it does not alter the
+   actor input, critic input, action order, reward values, command
+   distribution, or termination conditions.
+3. Treat observation shape as an external interface:
+   the actor input remains 69 values per frame and 690 values after 10-frame
+   flattening.
+4. Treat K1 joint order and `preserve_order=True` as deployment-critical.
+5. Any change that reintroduces `base_lin_vel` to the actor is a behavior
+   change, not a style refactor.

--- a/scripts/run_k1_fight_env.py
+++ b/scripts/run_k1_fight_env.py
@@ -1,0 +1,112 @@
+"""Run the Booster K1 Fight environment without starting RL training.
+
+Launch with DISPLAY set externally when using the GUI, for example:
+    DISPLAY=:1 python scripts/run_k1_fight_env.py
+"""
+
+from isaaclab.app import AppLauncher
+
+
+DEVICE = "cuda:0"
+HEADLESS = False
+
+NUM_ENVS = 1
+MAX_STEPS = 1000
+RESET_INTERVAL = 0
+PRINT_INTERVAL = 50
+SEED = 42
+
+CAMERA_ENV_INDEX = 0
+CAMERA_EYE = (2.0, 2.0, 0.5)
+CAMERA_LOOKAT = (0.0, 0.0, 0.0)
+
+
+app_launcher = AppLauncher({"device": DEVICE, "headless": HEADLESS})
+simulation_app = app_launcher.app
+
+import torch
+
+from isaaclab.envs import ManagerBasedRLEnv
+
+from booster_train.tasks.manager_based.beyond_mimic.robots.k1.fight_001.env_cfg import FlatWoStateEstimationEnvCfg
+
+
+def _configure_viewer(env_cfg: FlatWoStateEstimationEnvCfg) -> None:
+    env_cfg.viewer.origin_type = "asset_root"
+    env_cfg.viewer.asset_name = "robot"
+    env_cfg.viewer.env_index = CAMERA_ENV_INDEX
+    env_cfg.viewer.eye = CAMERA_EYE
+    env_cfg.viewer.lookat = CAMERA_LOOKAT
+
+
+def _disable_terminations(env_cfg: FlatWoStateEstimationEnvCfg) -> None:
+    env_cfg.terminations.time_out = None
+    env_cfg.terminations.anchor_pos = None
+    env_cfg.terminations.anchor_ori = None
+    env_cfg.terminations.ee_body_pos = None
+
+
+def _disable_randomization(env_cfg: FlatWoStateEstimationEnvCfg) -> None:
+    env_cfg.commands.motion.play = True
+    env_cfg.commands.motion.debug_vis = False
+    env_cfg.commands.motion.pose_range = {}
+    env_cfg.commands.motion.velocity_range = {}
+    env_cfg.commands.motion.joint_position_range = (0.0, 0.0)
+
+    env_cfg.events.physics_material = None
+    env_cfg.events.add_joint_default_pos = None
+    env_cfg.events.base_com = None
+    env_cfg.events.push_robot = None
+
+
+def main() -> None:
+    env_cfg = FlatWoStateEstimationEnvCfg()
+    env_cfg.scene.num_envs = NUM_ENVS
+    env_cfg.sim.device = DEVICE
+    env_cfg.seed = SEED
+    _configure_viewer(env_cfg)
+    _disable_terminations(env_cfg)
+    _disable_randomization(env_cfg)
+
+    env = ManagerBasedRLEnv(cfg=env_cfg)
+    env.reset()
+
+    print(
+        "[INFO]: Running Booster K1 Fight environment "
+        f"num_envs={NUM_ENVS}, max_steps={MAX_STEPS}, device={DEVICE}, terrain=flat, "
+        "action_mode=zero, randomization=off, terminations=off, camera_mode=robot"
+    )
+
+    count = 0
+    try:
+        with torch.inference_mode():
+            while simulation_app.is_running():
+                if MAX_STEPS > 0 and count >= MAX_STEPS:
+                    break
+
+                if RESET_INTERVAL > 0 and count > 0 and count % RESET_INTERVAL == 0:
+                    env.reset()
+                    print("-" * 80)
+                    print(f"[INFO]: Resetting environment at step {count}.")
+
+                actions = torch.zeros_like(env.action_manager.action)
+                obs, rew, terminated, truncated, _ = env.step(actions)
+
+                if PRINT_INTERVAL > 0 and count % PRINT_INTERVAL == 0:
+                    policy_obs = obs["policy"]
+                    done_count = int(torch.count_nonzero(terminated | truncated).item())
+                    print(
+                        f"[step {count:06d}] "
+                        f"reward_env0={rew[0].item(): .5f} "
+                        f"policy_obs_shape={tuple(policy_obs.shape)} "
+                        f"done_count={done_count}"
+                    )
+
+                count += 1
+    finally:
+        env.close()
+
+
+if __name__ == "__main__":
+    main()
+    simulation_app.close()

--- a/scripts/run_k1_from_unitree_velocity_env.py
+++ b/scripts/run_k1_from_unitree_velocity_env.py
@@ -1,0 +1,99 @@
+"""Launch the K1 port of the Unitree velocity task without training."""
+
+from __future__ import annotations
+
+import argparse
+import os
+
+from isaaclab.app import AppLauncher
+
+
+DEVICE = "cuda:0"
+HEADLESS = False
+NUM_ENVS = 1
+MAX_STEPS = 240
+PRINT_INTERVAL = 40
+
+
+parser = argparse.ArgumentParser(description="Smoke-test the K1 port of the Unitree velocity environment.")
+AppLauncher.add_app_launcher_args(parser)
+args_cli = parser.parse_args()
+args_cli.device = DEVICE
+args_cli.headless = HEADLESS
+
+app_launcher = AppLauncher(args_cli)
+simulation_app = app_launcher.app
+
+import torch
+from isaaclab.envs import ManagerBasedRLEnv
+
+from booster_train.tasks.manager_based.locomotion.robots.k1.unitree_velocity.env_cfg import K1UnitreeVelocityEnvCfg
+
+
+def _make_smoke_cfg() -> K1UnitreeVelocityEnvCfg:
+    env_cfg = K1UnitreeVelocityEnvCfg()
+    env_cfg.scene.num_envs = NUM_ENVS
+    env_cfg.sim.device = DEVICE
+
+    env_cfg.scene.terrain.terrain_type = "plane"
+    env_cfg.scene.terrain.terrain_generator = None
+    env_cfg.scene.terrain.max_init_terrain_level = None
+    env_cfg.curriculum.terrain_levels = None
+    env_cfg.curriculum.lin_vel_cmd_levels = None
+
+    env_cfg.commands.base_velocity.debug_vis = False
+    env_cfg.commands.base_velocity.ranges.lin_vel_x = (0.0, 0.0)
+    env_cfg.commands.base_velocity.ranges.lin_vel_y = (0.0, 0.0)
+    env_cfg.commands.base_velocity.ranges.ang_vel_z = (0.0, 0.0)
+
+    env_cfg.events.physics_material = None
+    env_cfg.events.add_base_mass = None
+    env_cfg.events.base_external_force_torque = None
+    env_cfg.events.reset_base = None
+    env_cfg.events.reset_robot_joints = None
+    env_cfg.events.push_robot = None
+
+    env_cfg.terminations.time_out = None
+    env_cfg.terminations.base_height = None
+    env_cfg.terminations.bad_orientation = None
+
+    env_cfg.viewer.origin_type = "asset_root"
+    env_cfg.viewer.asset_name = "robot"
+    env_cfg.viewer.eye = (2.5, -3.0, 1.2)
+    env_cfg.viewer.lookat = (0.0, 0.0, 0.6)
+    return env_cfg
+
+
+def main():
+    if not os.environ.get("DISPLAY"):
+        print("[WARN] DISPLAY is not set. Run with `export DISPLAY=:1` for GUI.")
+
+    env = ManagerBasedRLEnv(cfg=_make_smoke_cfg())
+    env.reset()
+
+    robot = env.scene["robot"]
+    print("[INFO] body_names:", robot.body_names)
+    print("[INFO] joint_names:", robot.joint_names)
+    print("[INFO] action_shape:", tuple(env.action_manager.action.shape))
+
+    count = 0
+    with torch.inference_mode():
+        while simulation_app.is_running() and count < MAX_STEPS:
+            actions = torch.zeros_like(env.action_manager.action)
+            obs, rew, terminated, truncated, _ = env.step(actions)
+            if count % PRINT_INTERVAL == 0:
+                done_count = int((terminated | truncated).sum().item())
+                print(
+                    f"[INFO] step={count:04d} "
+                    f"reward0={rew[0].item():.4f} "
+                    f"done_count={done_count} "
+                    f"policy_shape={tuple(obs['policy'].shape)}"
+                )
+            count += 1
+
+    env.close()
+    simulation_app.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/source/booster_train/booster_train/tasks/manager_based/locomotion/__init__.py
+++ b/source/booster_train/booster_train/tasks/manager_based/locomotion/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause

--- a/source/booster_train/booster_train/tasks/manager_based/locomotion/__init__.py
+++ b/source/booster_train/booster_train/tasks/manager_based/locomotion/__init__.py
@@ -1,4 +1,0 @@
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause

--- a/source/booster_train/booster_train/tasks/manager_based/locomotion/mdp/__init__.py
+++ b/source/booster_train/booster_train/tasks/manager_based/locomotion/mdp/__init__.py
@@ -1,0 +1,11 @@
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""MDP terms for Booster locomotion tasks."""
+
+from isaaclab_tasks.manager_based.locomotion.velocity.mdp import *  # noqa: F401, F403
+
+from .observations import *  # noqa: F401, F403
+from .rewards import *  # noqa: F401, F403

--- a/source/booster_train/booster_train/tasks/manager_based/locomotion/mdp/__init__.py
+++ b/source/booster_train/booster_train/tasks/manager_based/locomotion/mdp/__init__.py
@@ -1,8 +1,3 @@
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """MDP terms for Booster locomotion tasks."""
 
 from isaaclab_tasks.manager_based.locomotion.velocity.mdp import *  # noqa: F401, F403

--- a/source/booster_train/booster_train/tasks/manager_based/locomotion/mdp/observations.py
+++ b/source/booster_train/booster_train/tasks/manager_based/locomotion/mdp/observations.py
@@ -38,7 +38,7 @@ def k1_deploy_locomotion_observation(
     )
 
 
-def k1_legged_lab_critic_observation(
+def k1_privileged_locomotion_observation(
     env: ManagerBasedRLEnv,
     command_name: str,
     asset_cfg: SceneEntityCfg,
@@ -46,7 +46,7 @@ def k1_legged_lab_critic_observation(
     obs_dof_vel_scale: float,
     contact_threshold: float,
 ) -> torch.Tensor:
-    """Single-frame privileged critic observation following the LeggedLab locomotion recipe."""
+    """Single-frame privileged critic observation for K1 locomotion training."""
     asset: Articulation = env.scene[asset_cfg.name]
     contact_sensor: ContactSensor = env.scene.sensors[sensor_cfg.name]
     contacts = (

--- a/source/booster_train/booster_train/tasks/manager_based/locomotion/mdp/observations.py
+++ b/source/booster_train/booster_train/tasks/manager_based/locomotion/mdp/observations.py
@@ -1,8 +1,3 @@
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/source/booster_train/booster_train/tasks/manager_based/locomotion/mdp/observations.py
+++ b/source/booster_train/booster_train/tasks/manager_based/locomotion/mdp/observations.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+
+from isaaclab.assets import Articulation
+from isaaclab.managers import SceneEntityCfg
+from isaaclab.sensors import ContactSensor
+
+if TYPE_CHECKING:
+    from isaaclab.envs import ManagerBasedRLEnv
+
+
+def k1_deploy_locomotion_observation(
+    env: ManagerBasedRLEnv,
+    command_name: str,
+    asset_cfg: SceneEntityCfg,
+    obs_dof_vel_scale: float,
+) -> torch.Tensor:
+    """Single-frame observation compatible with deploy K1WalkControllerCfg."""
+    asset: Articulation = env.scene[asset_cfg.name]
+    joint_ids = asset_cfg.joint_ids
+
+    joint_pos_rel = asset.data.joint_pos[:, joint_ids] - asset.data.default_joint_pos[:, joint_ids]
+    joint_vel_scaled = asset.data.joint_vel[:, joint_ids] * obs_dof_vel_scale
+
+    return torch.cat(
+        (
+            asset.data.root_ang_vel_b,
+            asset.data.projected_gravity_b,
+            env.command_manager.get_command(command_name),
+            joint_pos_rel,
+            joint_vel_scaled,
+            env.action_manager.action,
+        ),
+        dim=-1,
+    )
+
+
+def k1_legged_lab_critic_observation(
+    env: ManagerBasedRLEnv,
+    command_name: str,
+    asset_cfg: SceneEntityCfg,
+    sensor_cfg: SceneEntityCfg,
+    obs_dof_vel_scale: float,
+    contact_threshold: float,
+) -> torch.Tensor:
+    """Single-frame privileged critic observation following the LeggedLab locomotion recipe."""
+    asset: Articulation = env.scene[asset_cfg.name]
+    contact_sensor: ContactSensor = env.scene.sensors[sensor_cfg.name]
+    contacts = (
+        contact_sensor.data.net_forces_w_history[:, :, sensor_cfg.body_ids, :].norm(dim=-1).max(dim=1)[0]
+        > contact_threshold
+    )
+
+    policy_obs = k1_deploy_locomotion_observation(
+        env=env,
+        command_name=command_name,
+        asset_cfg=asset_cfg,
+        obs_dof_vel_scale=obs_dof_vel_scale,
+    )
+    return torch.cat((policy_obs, asset.data.root_lin_vel_b, contacts.float()), dim=-1)

--- a/source/booster_train/booster_train/tasks/manager_based/locomotion/mdp/rewards.py
+++ b/source/booster_train/booster_train/tasks/manager_based/locomotion/mdp/rewards.py
@@ -1,10 +1,22 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
+
 import torch
 
 from isaaclab.assets import Articulation
 from isaaclab.managers import SceneEntityCfg
 from isaaclab.sensors import ContactSensor
+
+try:
+    from isaaclab.utils.math import quat_apply_inverse, yaw_quat
+except ImportError:
+    from isaaclab.utils.math import quat_rotate_inverse as quat_apply_inverse
+    from isaaclab.utils.math import yaw_quat
+
+if TYPE_CHECKING:
+    from isaaclab.envs import ManagerBasedRLEnv
 
 
 def k1_joint_torques_l2(env, asset_cfg: SceneEntityCfg = SceneEntityCfg("robot")) -> torch.Tensor:
@@ -53,3 +65,55 @@ def k1_feet_too_near_humanoid(
     feet_pos = asset.data.body_pos_w[:, asset_cfg.body_ids, :]
     distance = torch.norm(feet_pos[:, 0] - feet_pos[:, 1], dim=-1)
     return (threshold - distance).clamp(min=0.0)
+
+
+def k1_yaw_frame_lin_vel_xy(
+    env: ManagerBasedRLEnv,
+    asset_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+) -> torch.Tensor:
+    asset: Articulation = env.scene[asset_cfg.name]
+    vel_yaw = quat_apply_inverse(yaw_quat(asset.data.root_quat_w), asset.data.root_lin_vel_w[:, :3])
+    return vel_yaw[:, :2]
+
+
+def k1_command_direction_velocity(
+    env: ManagerBasedRLEnv,
+    command_name: str,
+    command_threshold: float = 0.1,
+    cap_to_command: bool = True,
+    asset_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+) -> torch.Tensor:
+    command_xy = env.command_manager.get_command(command_name)[:, :2]
+    command_norm = torch.linalg.norm(command_xy, dim=1)
+    command_dir = command_xy / torch.clamp(command_norm.unsqueeze(1), min=1.0e-6)
+    velocity = torch.sum(k1_yaw_frame_lin_vel_xy(env, asset_cfg) * command_dir, dim=1)
+    if cap_to_command:
+        velocity = torch.minimum(velocity, command_norm)
+    return torch.where(command_norm > command_threshold, velocity, torch.zeros_like(velocity))
+
+
+def k1_flat_forward_metrics(
+    env: ManagerBasedRLEnv,
+    env_ids: Sequence[int],
+    command_name: str = "base_velocity",
+    asset_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+) -> dict[str, torch.Tensor]:
+    """Log per-episode motion metrics without affecting rewards."""
+    asset: Articulation = env.scene[asset_cfg.name]
+    root_x = asset.data.root_pos_w[env_ids, 0] - env.scene.env_origins[env_ids, 0]
+    elapsed_time = torch.clamp(env.episode_length_buf[env_ids].to(torch.float32) * env.step_dt, min=env.step_dt)
+    speed = root_x / elapsed_time
+    command_speed = k1_command_direction_velocity(
+        env,
+        command_name=command_name,
+        cap_to_command=False,
+        asset_cfg=asset_cfg,
+    )[env_ids]
+    yaw_velocity = k1_yaw_frame_lin_vel_xy(env, asset_cfg)[env_ids]
+    return {
+        "distance_m": torch.mean(root_x),
+        "speed_mps": torch.mean(speed),
+        "command_direction_speed_mps": torch.mean(command_speed),
+        "yaw_frame_vel_x_mps": torch.mean(yaw_velocity[:, 0]),
+        "root_body_vel_x_mps": torch.mean(asset.data.root_lin_vel_b[env_ids, 0]),
+    }

--- a/source/booster_train/booster_train/tasks/manager_based/locomotion/mdp/rewards.py
+++ b/source/booster_train/booster_train/tasks/manager_based/locomotion/mdp/rewards.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from __future__ import annotations
+
+import torch
+
+from isaaclab.assets import Articulation
+from isaaclab.managers import SceneEntityCfg
+from isaaclab.sensors import ContactSensor
+
+
+def k1_joint_torques_l2(env, asset_cfg: SceneEntityCfg = SceneEntityCfg("robot")) -> torch.Tensor:
+    asset: Articulation = env.scene[asset_cfg.name]
+    return torch.sum(asset.data.applied_torque[:, asset_cfg.joint_ids].square(), dim=-1)
+
+
+def k1_joint_energy(env, asset_cfg: SceneEntityCfg = SceneEntityCfg("robot")) -> torch.Tensor:
+    asset: Articulation = env.scene[asset_cfg.name]
+    joint_power = torch.abs(
+        asset.data.applied_torque[:, asset_cfg.joint_ids] * asset.data.joint_vel[:, asset_cfg.joint_ids]
+    )
+    return torch.norm(joint_power, dim=-1)
+
+
+def action_l2_subset(env, action_indices: list[int] | tuple[int, ...]) -> torch.Tensor:
+    return torch.sum(torch.square(env.action_manager.action[:, action_indices]), dim=-1)
+
+
+def action_rate_l2_subset(env, action_indices: list[int] | tuple[int, ...]) -> torch.Tensor:
+    action = env.action_manager.action[:, action_indices]
+    prev_action = env.action_manager.prev_action[:, action_indices]
+    return torch.sum(torch.square(action - prev_action), dim=-1)
+
+
+def k1_body_force(env, sensor_cfg: SceneEntityCfg, threshold: float, max_reward: float) -> torch.Tensor:
+    contact_sensor: ContactSensor = env.scene.sensors[sensor_cfg.name]
+    reward = contact_sensor.data.net_forces_w[:, sensor_cfg.body_ids, 2].norm(dim=-1)
+    reward = torch.where(reward < threshold, torch.zeros_like(reward), reward - threshold)
+    return reward.clamp(min=0.0, max=max_reward)
+
+
+def k1_feet_stumble(env, sensor_cfg: SceneEntityCfg) -> torch.Tensor:
+    contact_sensor: ContactSensor = env.scene.sensors[sensor_cfg.name]
+    horizontal_force = torch.norm(contact_sensor.data.net_forces_w[:, sensor_cfg.body_ids, :2], dim=-1)
+    vertical_force = torch.abs(contact_sensor.data.net_forces_w[:, sensor_cfg.body_ids, 2])
+    return torch.any(horizontal_force > 5.0 * vertical_force, dim=-1).float()
+
+
+def k1_feet_too_near_humanoid(
+    env,
+    threshold: float,
+    asset_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+) -> torch.Tensor:
+    asset: Articulation = env.scene[asset_cfg.name]
+    feet_pos = asset.data.body_pos_w[:, asset_cfg.body_ids, :]
+    distance = torch.norm(feet_pos[:, 0] - feet_pos[:, 1], dim=-1)
+    return (threshold - distance).clamp(min=0.0)

--- a/source/booster_train/booster_train/tasks/manager_based/locomotion/mdp/rewards.py
+++ b/source/booster_train/booster_train/tasks/manager_based/locomotion/mdp/rewards.py
@@ -1,8 +1,3 @@
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 import torch

--- a/source/booster_train/booster_train/tasks/manager_based/locomotion/robots/__init__.py
+++ b/source/booster_train/booster_train/tasks/manager_based/locomotion/robots/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause

--- a/source/booster_train/booster_train/tasks/manager_based/locomotion/robots/__init__.py
+++ b/source/booster_train/booster_train/tasks/manager_based/locomotion/robots/__init__.py
@@ -1,4 +1,0 @@
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause

--- a/source/booster_train/booster_train/tasks/manager_based/locomotion/robots/k1/__init__.py
+++ b/source/booster_train/booster_train/tasks/manager_based/locomotion/robots/k1/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause

--- a/source/booster_train/booster_train/tasks/manager_based/locomotion/robots/k1/__init__.py
+++ b/source/booster_train/booster_train/tasks/manager_based/locomotion/robots/k1/__init__.py
@@ -1,4 +1,0 @@
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause

--- a/source/booster_train/booster_train/tasks/manager_based/locomotion/robots/k1/unitree_velocity/__init__.py
+++ b/source/booster_train/booster_train/tasks/manager_based/locomotion/robots/k1/unitree_velocity/__init__.py
@@ -1,0 +1,62 @@
+import gymnasium as gym
+
+
+gym.register(
+    id="Booster-K1-UnitreeVelocity-v0",
+    entry_point="isaaclab.envs:ManagerBasedRLEnv",
+    disable_env_checker=True,
+    kwargs={
+        "env_cfg_entry_point": f"{__name__}.env_cfg:K1UnitreeVelocityEnvCfg",
+        "rsl_rl_cfg_entry_point": f"{__name__}.ppo_cfg:PPORunnerCfg",
+    },
+)
+
+gym.register(
+    id="Booster-K1-UnitreeVelocity-v0-Play",
+    entry_point="isaaclab.envs:ManagerBasedRLEnv",
+    disable_env_checker=True,
+    kwargs={
+        "env_cfg_entry_point": f"{__name__}.env_cfg:K1UnitreeVelocityPlayEnvCfg",
+        "rsl_rl_cfg_entry_point": f"{__name__}.ppo_cfg:PPORunnerCfg",
+    },
+)
+
+gym.register(
+    id="Booster-K1-UnitreeVelocity-Flat-v0",
+    entry_point="isaaclab.envs:ManagerBasedRLEnv",
+    disable_env_checker=True,
+    kwargs={
+        "env_cfg_entry_point": f"{__name__}.env_cfg:K1UnitreeVelocityFlatEnvCfg",
+        "rsl_rl_cfg_entry_point": f"{__name__}.ppo_cfg:PPORunnerCfg",
+    },
+)
+
+gym.register(
+    id="Booster-K1-UnitreeVelocity-Flat-v0-Play",
+    entry_point="isaaclab.envs:ManagerBasedRLEnv",
+    disable_env_checker=True,
+    kwargs={
+        "env_cfg_entry_point": f"{__name__}.env_cfg:K1UnitreeVelocityFlatPlayEnvCfg",
+        "rsl_rl_cfg_entry_point": f"{__name__}.ppo_cfg:PPORunnerCfg",
+    },
+)
+
+gym.register(
+    id="Booster-K1-UnitreeVelocity-FlatForward-v0",
+    entry_point="isaaclab.envs:ManagerBasedRLEnv",
+    disable_env_checker=True,
+    kwargs={
+        "env_cfg_entry_point": f"{__name__}.env_cfg:K1UnitreeVelocityFlatForwardEnvCfg",
+        "rsl_rl_cfg_entry_point": f"{__name__}.ppo_cfg:PPORunnerCfg",
+    },
+)
+
+gym.register(
+    id="Booster-K1-UnitreeVelocity-FlatForward-v0-Play",
+    entry_point="isaaclab.envs:ManagerBasedRLEnv",
+    disable_env_checker=True,
+    kwargs={
+        "env_cfg_entry_point": f"{__name__}.env_cfg:K1UnitreeVelocityFlatForwardPlayEnvCfg",
+        "rsl_rl_cfg_entry_point": f"{__name__}.ppo_cfg:PPORunnerCfg",
+    },
+)

--- a/source/booster_train/booster_train/tasks/manager_based/locomotion/robots/k1/unitree_velocity/env_cfg.py
+++ b/source/booster_train/booster_train/tasks/manager_based/locomotion/robots/k1/unitree_velocity/env_cfg.py
@@ -1,0 +1,527 @@
+from __future__ import annotations
+
+import math
+
+import isaaclab.sim as sim_utils
+import isaaclab.terrains as terrain_gen
+from isaaclab.assets import ArticulationCfg, AssetBaseCfg
+from isaaclab.envs import ManagerBasedRLEnvCfg
+from isaaclab.managers import CurriculumTermCfg as CurrTerm
+from isaaclab.managers import EventTermCfg as EventTerm
+from isaaclab.managers import ObservationGroupCfg as ObsGroup
+from isaaclab.managers import ObservationTermCfg as ObsTerm
+from isaaclab.managers import RewardTermCfg as RewTerm
+from isaaclab.managers import SceneEntityCfg
+from isaaclab.managers import TerminationTermCfg as DoneTerm
+from isaaclab.scene import InteractiveSceneCfg
+from isaaclab.sensors import ContactSensorCfg, RayCasterCfg, patterns
+from isaaclab.terrains import TerrainImporterCfg
+from isaaclab.utils import configclass
+from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR, ISAACLAB_NUCLEUS_DIR
+from isaaclab.utils.noise import AdditiveUniformNoiseCfg as Unoise
+
+from booster_train.assets.robots.booster import BOOSTER_K1_CFG
+
+from . import mdp
+
+K1_BASE_BODY_NAME = "Trunk"
+K1_FOOT_BODY_NAMES = ["left_foot_link", "right_foot_link"]
+K1_ACTION_JOINT_NAMES = [
+    "AAHead_yaw",
+    "Head_pitch",
+    "ALeft_Shoulder_Pitch",
+    "Left_Shoulder_Roll",
+    "Left_Elbow_Pitch",
+    "Left_Elbow_Yaw",
+    "ARight_Shoulder_Pitch",
+    "Right_Shoulder_Roll",
+    "Right_Elbow_Pitch",
+    "Right_Elbow_Yaw",
+    "Left_Hip_Pitch",
+    "Left_Hip_Roll",
+    "Left_Hip_Yaw",
+    "Left_Knee_Pitch",
+    "Left_Ankle_Pitch",
+    "Left_Ankle_Roll",
+    "Right_Hip_Pitch",
+    "Right_Hip_Roll",
+    "Right_Hip_Yaw",
+    "Right_Knee_Pitch",
+    "Right_Ankle_Pitch",
+    "Right_Ankle_Roll",
+]
+K1_ARM_JOINT_NAMES = [".*Shoulder.*", ".*Elbow.*"]
+K1_HIP_DEVIATION_JOINT_NAMES = [".*_Hip_Roll", ".*_Hip_Yaw"]
+K1_DEFAULT_BASE_HEIGHT = 0.57
+K1_DEFAULT_JOINT_POS_BY_NAME = {
+    "AAHead_yaw": 0.0,
+    "Head_pitch": 0.0,
+    "ALeft_Shoulder_Pitch": 0.2,
+    "Left_Shoulder_Roll": -1.25,
+    "Left_Elbow_Pitch": 0.0,
+    "Left_Elbow_Yaw": -0.5,
+    "ARight_Shoulder_Pitch": 0.2,
+    "Right_Shoulder_Roll": 1.25,
+    "Right_Elbow_Pitch": 0.0,
+    "Right_Elbow_Yaw": 0.5,
+    "Left_Hip_Pitch": -0.15,
+    "Left_Hip_Roll": 0.0,
+    "Left_Hip_Yaw": 0.0,
+    "Left_Knee_Pitch": 0.3,
+    "Left_Ankle_Pitch": -0.15,
+    "Left_Ankle_Roll": 0.0,
+    "Right_Hip_Pitch": -0.15,
+    "Right_Hip_Roll": 0.0,
+    "Right_Hip_Yaw": 0.0,
+    "Right_Knee_Pitch": 0.3,
+    "Right_Ankle_Pitch": -0.15,
+    "Right_Ankle_Roll": 0.0,
+}
+
+COBBLESTONE_ROAD_CFG = terrain_gen.TerrainGeneratorCfg(
+    size=(8.0, 8.0),
+    border_width=20.0,
+    num_rows=9,
+    num_cols=21,
+    horizontal_scale=0.1,
+    vertical_scale=0.005,
+    slope_threshold=0.75,
+    difficulty_range=(0.0, 1.0),
+    use_cache=False,
+    sub_terrains={
+        "flat": terrain_gen.MeshPlaneTerrainCfg(proportion=0.5),
+    },
+)
+
+
+@configclass
+class RobotSceneCfg(InteractiveSceneCfg):
+    """Configuration for the terrain scene with a legged robot."""
+
+    terrain = TerrainImporterCfg(
+        prim_path="/World/ground",
+        terrain_type="generator",
+        terrain_generator=COBBLESTONE_ROAD_CFG,
+        max_init_terrain_level=COBBLESTONE_ROAD_CFG.num_rows - 1,
+        collision_group=-1,
+        physics_material=sim_utils.RigidBodyMaterialCfg(
+            friction_combine_mode="multiply",
+            restitution_combine_mode="multiply",
+            static_friction=1.0,
+            dynamic_friction=1.0,
+        ),
+        visual_material=sim_utils.MdlFileCfg(
+            mdl_path=f"{ISAACLAB_NUCLEUS_DIR}/Materials/TilesMarbleSpiderWhiteBrickBondHoned/"
+            "TilesMarbleSpiderWhiteBrickBondHoned.mdl",
+            project_uvw=True,
+            texture_scale=(0.25, 0.25),
+        ),
+        debug_vis=False,
+    )
+    robot: ArticulationCfg = BOOSTER_K1_CFG.replace(
+        prim_path="{ENV_REGEX_NS}/Robot",
+        init_state=ArticulationCfg.InitialStateCfg(
+            pos=(0.0, 0.0, K1_DEFAULT_BASE_HEIGHT),
+            joint_pos=K1_DEFAULT_JOINT_POS_BY_NAME,
+            joint_vel={".*": 0.0},
+        ),
+    )
+    height_scanner = RayCasterCfg(
+        prim_path=f"{{ENV_REGEX_NS}}/Robot/{K1_BASE_BODY_NAME}",
+        offset=RayCasterCfg.OffsetCfg(pos=(0.0, 0.0, 20.0)),
+        ray_alignment="yaw",
+        pattern_cfg=patterns.GridPatternCfg(resolution=0.1, size=[1.6, 1.0]),
+        debug_vis=False,
+        mesh_prim_paths=["/World/ground"],
+    )
+    contact_forces = ContactSensorCfg(prim_path="{ENV_REGEX_NS}/Robot/.*", history_length=3, track_air_time=True)
+    sky_light = AssetBaseCfg(
+        prim_path="/World/skyLight",
+        spawn=sim_utils.DomeLightCfg(
+            intensity=750.0,
+            texture_file=f"{ISAAC_NUCLEUS_DIR}/Materials/Textures/Skies/PolyHaven/kloofendal_43d_clear_puresky_4k.hdr",
+        ),
+    )
+
+
+@configclass
+class EventCfg:
+    """Configuration for events."""
+
+    physics_material = EventTerm(
+        func=mdp.randomize_rigid_body_material,
+        mode="startup",
+        params={
+            "asset_cfg": SceneEntityCfg("robot", body_names=".*"),
+            "static_friction_range": (0.3, 1.0),
+            "dynamic_friction_range": (0.3, 1.0),
+            "restitution_range": (0.0, 0.0),
+            "num_buckets": 64,
+        },
+    )
+
+    add_base_mass = EventTerm(
+        func=mdp.randomize_rigid_body_mass,
+        mode="startup",
+        params={
+            "asset_cfg": SceneEntityCfg("robot", body_names=K1_BASE_BODY_NAME),
+            "mass_distribution_params": (-1.0, 3.0),
+            "operation": "add",
+        },
+    )
+
+    base_external_force_torque = EventTerm(
+        func=mdp.apply_external_force_torque,
+        mode="reset",
+        params={
+            "asset_cfg": SceneEntityCfg("robot", body_names=K1_BASE_BODY_NAME),
+            "force_range": (0.0, 0.0),
+            "torque_range": (-0.0, 0.0),
+        },
+    )
+
+    reset_base = EventTerm(
+        func=mdp.reset_root_state_uniform,
+        mode="reset",
+        params={
+            "pose_range": {"x": (-0.5, 0.5), "y": (-0.5, 0.5), "yaw": (-3.14, 3.14)},
+            "velocity_range": {
+                "x": (0.0, 0.0),
+                "y": (0.0, 0.0),
+                "z": (0.0, 0.0),
+                "roll": (0.0, 0.0),
+                "pitch": (0.0, 0.0),
+                "yaw": (0.0, 0.0),
+            },
+        },
+    )
+
+    reset_robot_joints = EventTerm(
+        func=mdp.reset_joints_by_scale,
+        mode="reset",
+        params={
+            "position_range": (1.0, 1.0),
+            "velocity_range": (-1.0, 1.0),
+        },
+    )
+
+    push_robot = EventTerm(
+        func=mdp.push_by_setting_velocity,
+        mode="interval",
+        interval_range_s=(5.0, 5.0),
+        params={"velocity_range": {"x": (-0.5, 0.5), "y": (-0.5, 0.5)}},
+    )
+
+
+@configclass
+class CommandsCfg:
+    """Command specifications for the MDP."""
+
+    base_velocity = mdp.UniformLevelVelocityCommandCfg(
+        asset_name="robot",
+        resampling_time_range=(10.0, 10.0),
+        rel_standing_envs=0.02,
+        rel_heading_envs=1.0,
+        heading_command=False,
+        debug_vis=True,
+        ranges=mdp.UniformLevelVelocityCommandCfg.Ranges(
+            lin_vel_x=(-0.1, 0.1), lin_vel_y=(-0.1, 0.1), ang_vel_z=(-0.1, 0.1)
+        ),
+        limit_ranges=mdp.UniformLevelVelocityCommandCfg.Ranges(
+            lin_vel_x=(-0.5, 1.0), lin_vel_y=(-0.3, 0.3), ang_vel_z=(-0.2, 0.2)
+        ),
+    )
+
+
+@configclass
+class ActionsCfg:
+    """Action specifications for the MDP."""
+
+    JointPositionAction = mdp.JointPositionActionCfg(
+        asset_name="robot",
+        joint_names=K1_ACTION_JOINT_NAMES,
+        scale=0.25,
+        use_default_offset=True,
+        preserve_order=True,
+    )
+
+
+@configclass
+class ObservationsCfg:
+    """Observation specifications for the MDP."""
+
+    @configclass
+    class PolicyCfg(ObsGroup):
+        """Observations for policy group."""
+
+        base_ang_vel = ObsTerm(func=mdp.base_ang_vel, scale=0.2, noise=Unoise(n_min=-0.2, n_max=0.2))
+        projected_gravity = ObsTerm(func=mdp.projected_gravity, noise=Unoise(n_min=-0.05, n_max=0.05))
+        velocity_commands = ObsTerm(func=mdp.generated_commands, params={"command_name": "base_velocity"})
+        joint_pos_rel = ObsTerm(
+            func=mdp.joint_pos_rel,
+            params={"asset_cfg": SceneEntityCfg("robot", joint_names=K1_ACTION_JOINT_NAMES, preserve_order=True)},
+            noise=Unoise(n_min=-0.01, n_max=0.01),
+        )
+        joint_vel_rel = ObsTerm(
+            func=mdp.joint_vel_rel,
+            params={"asset_cfg": SceneEntityCfg("robot", joint_names=K1_ACTION_JOINT_NAMES, preserve_order=True)},
+            scale=0.05,
+            noise=Unoise(n_min=-1.5, n_max=1.5),
+        )
+        last_action = ObsTerm(func=mdp.last_action)
+
+        def __post_init__(self):
+            self.history_length = 5
+            self.enable_corruption = True
+            self.concatenate_terms = True
+
+    policy: PolicyCfg = PolicyCfg()
+
+    @configclass
+    class CriticCfg(ObsGroup):
+        """Observations for critic group."""
+
+        base_lin_vel = ObsTerm(func=mdp.base_lin_vel)
+        base_ang_vel = ObsTerm(func=mdp.base_ang_vel, scale=0.2)
+        projected_gravity = ObsTerm(func=mdp.projected_gravity)
+        velocity_commands = ObsTerm(func=mdp.generated_commands, params={"command_name": "base_velocity"})
+        joint_pos_rel = ObsTerm(
+            func=mdp.joint_pos_rel,
+            params={"asset_cfg": SceneEntityCfg("robot", joint_names=K1_ACTION_JOINT_NAMES, preserve_order=True)},
+        )
+        joint_vel_rel = ObsTerm(
+            func=mdp.joint_vel_rel,
+            params={"asset_cfg": SceneEntityCfg("robot", joint_names=K1_ACTION_JOINT_NAMES, preserve_order=True)},
+            scale=0.05,
+        )
+        last_action = ObsTerm(func=mdp.last_action)
+
+        def __post_init__(self):
+            self.history_length = 5
+
+    critic: CriticCfg = CriticCfg()
+
+
+@configclass
+class RewardsCfg:
+    """Reward terms for the MDP."""
+
+    track_lin_vel_xy = RewTerm(
+        func=mdp.track_lin_vel_xy_yaw_frame_exp,
+        weight=1.0,
+        params={"command_name": "base_velocity", "std": math.sqrt(0.25)},
+    )
+    track_ang_vel_z = RewTerm(
+        func=mdp.track_ang_vel_z_exp, weight=0.5, params={"command_name": "base_velocity", "std": math.sqrt(0.25)}
+    )
+
+    alive = RewTerm(func=mdp.is_alive, weight=0.15)
+
+    base_linear_velocity = RewTerm(func=mdp.lin_vel_z_l2, weight=-2.0)
+    base_angular_velocity = RewTerm(func=mdp.ang_vel_xy_l2, weight=-0.05)
+    joint_vel = RewTerm(func=mdp.joint_vel_l2, weight=-0.001)
+    joint_acc = RewTerm(func=mdp.joint_acc_l2, weight=-2.5e-7)
+    action_rate = RewTerm(func=mdp.action_rate_l2, weight=-0.05)
+    dof_pos_limits = RewTerm(func=mdp.joint_pos_limits, weight=-5.0)
+    energy = RewTerm(func=mdp.energy, weight=-2e-5)
+
+    joint_deviation_arms = RewTerm(
+        func=mdp.joint_deviation_l1,
+        weight=-0.1,
+        params={"asset_cfg": SceneEntityCfg("robot", joint_names=K1_ARM_JOINT_NAMES)},
+    )
+    joint_deviation_hips = RewTerm(
+        func=mdp.joint_deviation_l1,
+        weight=-1.0,
+        params={"asset_cfg": SceneEntityCfg("robot", joint_names=K1_HIP_DEVIATION_JOINT_NAMES)},
+    )
+
+    flat_orientation_l2 = RewTerm(func=mdp.flat_orientation_l2, weight=-5.0)
+    base_height = RewTerm(func=mdp.base_height_l2, weight=-10, params={"target_height": K1_DEFAULT_BASE_HEIGHT})
+
+    gait = RewTerm(
+        func=mdp.feet_gait,
+        weight=0.5,
+        params={
+            "period": 0.8,
+            "offset": [0.0, 0.5],
+            "threshold": 0.55,
+            "command_name": "base_velocity",
+            "sensor_cfg": SceneEntityCfg("contact_forces", body_names=K1_FOOT_BODY_NAMES),
+        },
+    )
+    feet_slide = RewTerm(
+        func=mdp.feet_slide,
+        weight=-0.2,
+        params={
+            "asset_cfg": SceneEntityCfg("robot", body_names=K1_FOOT_BODY_NAMES),
+            "sensor_cfg": SceneEntityCfg("contact_forces", body_names=K1_FOOT_BODY_NAMES),
+        },
+    )
+    feet_clearance = RewTerm(
+        func=mdp.foot_clearance_reward,
+        weight=1.0,
+        params={
+            "std": 0.05,
+            "tanh_mult": 2.0,
+            "target_height": 0.1,
+            "asset_cfg": SceneEntityCfg("robot", body_names=K1_FOOT_BODY_NAMES),
+        },
+    )
+
+    undesired_contacts = RewTerm(
+        func=mdp.undesired_contacts,
+        weight=-1,
+        params={
+            "threshold": 1,
+            "sensor_cfg": SceneEntityCfg(
+                "contact_forces",
+                body_names=["^(?!left_foot_link$)(?!right_foot_link$).+$"],
+            ),
+        },
+    )
+
+
+@configclass
+class TerminationsCfg:
+    """Termination terms for the MDP."""
+
+    time_out = DoneTerm(func=mdp.time_out, time_out=True)
+    base_height = DoneTerm(func=mdp.root_height_below_minimum, params={"minimum_height": 0.2})
+    bad_orientation = DoneTerm(func=mdp.bad_orientation, params={"limit_angle": 0.8})
+
+
+@configclass
+class CurriculumCfg:
+    """Curriculum terms for the MDP."""
+
+    terrain_levels = CurrTerm(func=mdp.terrain_levels_vel)
+    lin_vel_cmd_levels = CurrTerm(mdp.lin_vel_cmd_levels)
+
+
+@configclass
+class FlatForwardCurriculumCfg(CurriculumCfg):
+    """Reset-time metrics for the first flat-forward walking check."""
+
+    flat_forward_metrics = CurrTerm(
+        func=mdp.flat_forward_metrics,
+        params={"asset_cfg": SceneEntityCfg("robot")},
+    )
+
+
+@configclass
+class K1UnitreeVelocityEnvCfg(ManagerBasedRLEnvCfg):
+    """Configuration for the K1 port of the Unitree velocity-tracking environment."""
+
+    scene: RobotSceneCfg = RobotSceneCfg(num_envs=4096, env_spacing=2.5)
+    observations: ObservationsCfg = ObservationsCfg()
+    actions: ActionsCfg = ActionsCfg()
+    commands: CommandsCfg = CommandsCfg()
+    rewards: RewardsCfg = RewardsCfg()
+    terminations: TerminationsCfg = TerminationsCfg()
+    events: EventCfg = EventCfg()
+    curriculum: CurriculumCfg = CurriculumCfg()
+
+    def __post_init__(self):
+        """Post initialization."""
+        self.decimation = 4
+        self.episode_length_s = 20.0
+        self.sim.dt = 0.005
+        self.sim.render_interval = self.decimation
+        self.sim.physics_material = self.scene.terrain.physics_material
+        self.sim.physx.gpu_max_rigid_patch_count = 10 * 2**15
+
+        self.scene.contact_forces.update_period = self.sim.dt
+        self.scene.height_scanner.update_period = self.decimation * self.sim.dt
+
+        if getattr(self.curriculum, "terrain_levels", None) is not None:
+            if self.scene.terrain.terrain_generator is not None:
+                self.scene.terrain.terrain_generator.curriculum = True
+        else:
+            if self.scene.terrain.terrain_generator is not None:
+                self.scene.terrain.terrain_generator.curriculum = False
+
+
+@configclass
+class K1UnitreeVelocityPlayEnvCfg(K1UnitreeVelocityEnvCfg):
+    def __post_init__(self):
+        super().__post_init__()
+        self.scene.num_envs = 32
+        self.scene.terrain.terrain_generator.num_rows = 2
+        self.scene.terrain.terrain_generator.num_cols = 10
+        self.commands.base_velocity.ranges = self.commands.base_velocity.limit_ranges
+
+
+@configclass
+class K1UnitreeVelocityFlatEnvCfg(K1UnitreeVelocityEnvCfg):
+    """Flat-floor variant for checking whether the K1 port can learn without disturbances."""
+
+    def __post_init__(self):
+        super().__post_init__()
+
+        self.scene.terrain.terrain_type = "plane"
+        self.scene.terrain.terrain_generator = None
+        self.scene.terrain.max_init_terrain_level = None
+
+        self.curriculum.terrain_levels = None
+        self.curriculum.lin_vel_cmd_levels = None
+
+        self.events.physics_material = None
+        self.events.add_base_mass = None
+        self.events.base_external_force_torque = None
+        self.events.push_robot = None
+        self.events.reset_base.params["pose_range"] = {"x": (0.0, 0.0), "y": (0.0, 0.0), "yaw": (0.0, 0.0)}
+        self.events.reset_base.params["velocity_range"] = {
+            "x": (0.0, 0.0),
+            "y": (0.0, 0.0),
+            "z": (0.0, 0.0),
+            "roll": (0.0, 0.0),
+            "pitch": (0.0, 0.0),
+            "yaw": (0.0, 0.0),
+        }
+        self.events.reset_robot_joints.params["position_range"] = (1.0, 1.0)
+        self.events.reset_robot_joints.params["velocity_range"] = (0.0, 0.0)
+
+
+@configclass
+class K1UnitreeVelocityFlatPlayEnvCfg(K1UnitreeVelocityFlatEnvCfg):
+    def __post_init__(self):
+        super().__post_init__()
+        self.scene.num_envs = 32
+        self.commands.base_velocity.ranges = self.commands.base_velocity.limit_ranges
+
+
+@configclass
+class K1UnitreeVelocityFlatForwardEnvCfg(K1UnitreeVelocityFlatEnvCfg):
+    """Fixed-forward variant for the first walking sanity check."""
+
+    curriculum: FlatForwardCurriculumCfg = FlatForwardCurriculumCfg()
+
+    def __post_init__(self):
+        super().__post_init__()
+
+        self.scene.height_scanner = None
+
+        self.commands.base_velocity.debug_vis = False
+        self.commands.base_velocity.rel_standing_envs = 0.0
+        self.commands.base_velocity.rel_heading_envs = 0.0
+        self.commands.base_velocity.heading_command = False
+        self.commands.base_velocity.ranges.lin_vel_x = (0.3, 0.3)
+        self.commands.base_velocity.ranges.lin_vel_y = (0.0, 0.0)
+        self.commands.base_velocity.ranges.ang_vel_z = (0.0, 0.0)
+        self.commands.base_velocity.limit_ranges.lin_vel_x = (0.3, 0.3)
+        self.commands.base_velocity.limit_ranges.lin_vel_y = (0.0, 0.0)
+        self.commands.base_velocity.limit_ranges.ang_vel_z = (0.0, 0.0)
+
+        self.observations.policy.enable_corruption = False
+        self.observations.policy.base_ang_vel.noise = None
+        self.observations.policy.projected_gravity.noise = None
+        self.observations.policy.joint_pos_rel.noise = None
+        self.observations.policy.joint_vel_rel.noise = None
+
+
+@configclass
+class K1UnitreeVelocityFlatForwardPlayEnvCfg(K1UnitreeVelocityFlatForwardEnvCfg):
+    def __post_init__(self):
+        super().__post_init__()
+        self.scene.num_envs = 1

--- a/source/booster_train/booster_train/tasks/manager_based/locomotion/robots/k1/unitree_velocity/mdp.py
+++ b/source/booster_train/booster_train/tasks/manager_based/locomotion/robots/k1/unitree_velocity/mdp.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import MISSING
+from typing import TYPE_CHECKING
+
+import torch
+
+try:
+    from isaaclab.utils.math import quat_apply_inverse, yaw_quat
+except ImportError:
+    from isaaclab.utils.math import quat_rotate_inverse as quat_apply_inverse
+    from isaaclab.utils.math import yaw_quat
+from isaaclab.assets import Articulation, RigidObject
+from isaaclab.envs.mdp import *  # noqa: F401, F403
+from isaaclab.envs.mdp import UniformVelocityCommandCfg
+from isaaclab.managers import SceneEntityCfg
+from isaaclab.sensors import ContactSensor
+from isaaclab.utils import configclass
+from isaaclab_tasks.manager_based.locomotion.velocity.mdp import *  # noqa: F401, F403
+
+if TYPE_CHECKING:
+    from isaaclab.envs import ManagerBasedRLEnv
+
+
+@configclass
+class UniformLevelVelocityCommandCfg(UniformVelocityCommandCfg):
+    limit_ranges: UniformVelocityCommandCfg.Ranges = MISSING
+
+
+def lin_vel_cmd_levels(
+    env: ManagerBasedRLEnv,
+    env_ids: Sequence[int],
+    reward_term_name: str = "track_lin_vel_xy",
+) -> torch.Tensor:
+    command_term = env.command_manager.get_term("base_velocity")
+    ranges = command_term.cfg.ranges
+    limit_ranges = command_term.cfg.limit_ranges
+
+    reward_term = env.reward_manager.get_term_cfg(reward_term_name)
+    reward = torch.mean(env.reward_manager._episode_sums[reward_term_name][env_ids]) / env.max_episode_length_s
+
+    if env.common_step_counter % env.max_episode_length == 0:
+        if reward > reward_term.weight * 0.8:
+            delta_command = torch.tensor([-0.1, 0.1], device=env.device)
+            ranges.lin_vel_x = torch.clamp(
+                torch.tensor(ranges.lin_vel_x, device=env.device) + delta_command,
+                limit_ranges.lin_vel_x[0],
+                limit_ranges.lin_vel_x[1],
+            ).tolist()
+            ranges.lin_vel_y = torch.clamp(
+                torch.tensor(ranges.lin_vel_y, device=env.device) + delta_command,
+                limit_ranges.lin_vel_y[0],
+                limit_ranges.lin_vel_y[1],
+            ).tolist()
+
+    return torch.tensor(ranges.lin_vel_x[1], device=env.device)
+
+
+def yaw_frame_lin_vel_xy(
+    env: ManagerBasedRLEnv,
+    asset_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+) -> torch.Tensor:
+    asset: Articulation = env.scene[asset_cfg.name]
+    vel_yaw = quat_apply_inverse(yaw_quat(asset.data.root_quat_w), asset.data.root_lin_vel_w[:, :3])
+    return vel_yaw[:, :2]
+
+
+def command_direction_velocity(
+    env: ManagerBasedRLEnv,
+    command_name: str,
+    command_threshold: float = 0.1,
+    cap_to_command: bool = True,
+    asset_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+) -> torch.Tensor:
+    command_xy = env.command_manager.get_command(command_name)[:, :2]
+    command_norm = torch.linalg.norm(command_xy, dim=1)
+    command_dir = command_xy / torch.clamp(command_norm.unsqueeze(1), min=1.0e-6)
+    velocity = torch.sum(yaw_frame_lin_vel_xy(env, asset_cfg) * command_dir, dim=1)
+    if cap_to_command:
+        velocity = torch.minimum(velocity, command_norm)
+    return torch.where(command_norm > command_threshold, velocity, torch.zeros_like(velocity))
+
+
+def flat_forward_metrics(
+    env: ManagerBasedRLEnv,
+    env_ids: Sequence[int],
+    asset_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+) -> dict[str, torch.Tensor]:
+    """Log per-episode forward distance for the fixed-start flat-forward task."""
+    asset: Articulation = env.scene[asset_cfg.name]
+    root_x = asset.data.root_pos_w[env_ids, 0] - env.scene.env_origins[env_ids, 0]
+    elapsed_time = torch.clamp(env.episode_length_buf[env_ids].to(torch.float32) * env.step_dt, min=env.step_dt)
+    speed = root_x / elapsed_time
+    command_speed = command_direction_velocity(
+        env, command_name="base_velocity", cap_to_command=False, asset_cfg=asset_cfg
+    )[env_ids]
+    yaw_velocity = yaw_frame_lin_vel_xy(env, asset_cfg)[env_ids]
+    return {
+        "distance_m": torch.mean(root_x),
+        "speed_mps": torch.mean(speed),
+        "command_direction_speed_mps": torch.mean(command_speed),
+        "yaw_frame_vel_x_mps": torch.mean(yaw_velocity[:, 0]),
+        "root_body_vel_x_mps": torch.mean(asset.data.root_lin_vel_b[env_ids, 0]),
+    }
+
+
+def gait_phase(env: ManagerBasedRLEnv, period: float) -> torch.Tensor:
+    if not hasattr(env, "episode_length_buf"):
+        env.episode_length_buf = torch.zeros(env.num_envs, device=env.device, dtype=torch.long)
+
+    global_phase = (env.episode_length_buf * env.step_dt) % period / period
+
+    phase = torch.zeros(env.num_envs, 2, device=env.device)
+    phase[:, 0] = torch.sin(global_phase * torch.pi * 2.0)
+    phase[:, 1] = torch.cos(global_phase * torch.pi * 2.0)
+    return phase
+
+
+def energy(env: ManagerBasedRLEnv, asset_cfg: SceneEntityCfg = SceneEntityCfg("robot")) -> torch.Tensor:
+    asset: Articulation = env.scene[asset_cfg.name]
+
+    qvel = asset.data.joint_vel[:, asset_cfg.joint_ids]
+    qfrc = asset.data.applied_torque[:, asset_cfg.joint_ids]
+    return torch.sum(torch.abs(qvel) * torch.abs(qfrc), dim=-1)
+
+
+def foot_clearance_reward(
+    env: ManagerBasedRLEnv, asset_cfg: SceneEntityCfg, target_height: float, std: float, tanh_mult: float
+) -> torch.Tensor:
+    asset: RigidObject = env.scene[asset_cfg.name]
+    foot_z_target_error = torch.square(asset.data.body_pos_w[:, asset_cfg.body_ids, 2] - target_height)
+    foot_velocity_tanh = torch.tanh(tanh_mult * torch.norm(asset.data.body_lin_vel_w[:, asset_cfg.body_ids, :2], dim=2))
+    reward = foot_z_target_error * foot_velocity_tanh
+    return torch.exp(-torch.sum(reward, dim=1) / std)
+
+
+def feet_gait(
+    env: ManagerBasedRLEnv,
+    period: float,
+    offset: list[float],
+    sensor_cfg: SceneEntityCfg,
+    threshold: float = 0.5,
+    command_name=None,
+) -> torch.Tensor:
+    contact_sensor: ContactSensor = env.scene.sensors[sensor_cfg.name]
+    is_contact = contact_sensor.data.current_contact_time[:, sensor_cfg.body_ids] > 0
+
+    global_phase = ((env.episode_length_buf * env.step_dt) % period / period).unsqueeze(1)
+    phases = []
+    for offset_ in offset:
+        phase = (global_phase + offset_) % 1.0
+        phases.append(phase)
+    leg_phase = torch.cat(phases, dim=-1)
+
+    reward = torch.zeros(env.num_envs, dtype=torch.float, device=env.device)
+    for i in range(len(sensor_cfg.body_ids)):
+        is_stance = leg_phase[:, i] < threshold
+        reward += ~(is_stance ^ is_contact[:, i])
+
+    if command_name is not None:
+        cmd_norm = torch.norm(env.command_manager.get_command(command_name), dim=1)
+        reward *= cmd_norm > 0.1
+    return reward
+
+
+def feet_height_body(
+    env: ManagerBasedRLEnv,
+    command_name: str,
+    asset_cfg: SceneEntityCfg,
+    target_height: float,
+    tanh_mult: float,
+) -> torch.Tensor:
+    asset: RigidObject = env.scene[asset_cfg.name]
+    cur_footpos_translated = asset.data.body_pos_w[:, asset_cfg.body_ids, :] - asset.data.root_pos_w[:, :].unsqueeze(1)
+    footpos_in_body_frame = torch.zeros(env.num_envs, len(asset_cfg.body_ids), 3, device=env.device)
+    cur_footvel_translated = asset.data.body_lin_vel_w[:, asset_cfg.body_ids, :] - asset.data.root_lin_vel_w[
+        :, :
+    ].unsqueeze(1)
+    footvel_in_body_frame = torch.zeros(env.num_envs, len(asset_cfg.body_ids), 3, device=env.device)
+    for i in range(len(asset_cfg.body_ids)):
+        footpos_in_body_frame[:, i, :] = quat_apply_inverse(asset.data.root_quat_w, cur_footpos_translated[:, i, :])
+        footvel_in_body_frame[:, i, :] = quat_apply_inverse(asset.data.root_quat_w, cur_footvel_translated[:, i, :])
+    foot_z_target_error = torch.square(footpos_in_body_frame[:, :, 2] - target_height).view(env.num_envs, -1)
+    foot_velocity_tanh = torch.tanh(tanh_mult * torch.norm(footvel_in_body_frame[:, :, :2], dim=2))
+    reward = torch.sum(foot_z_target_error * foot_velocity_tanh, dim=1)
+    reward *= torch.linalg.norm(env.command_manager.get_command(command_name), dim=1) > 0.1
+    reward *= torch.clamp(-env.scene["robot"].data.projected_gravity_b[:, 2], 0, 0.7) / 0.7
+    return reward

--- a/source/booster_train/booster_train/tasks/manager_based/locomotion/robots/k1/unitree_velocity/ppo_cfg.py
+++ b/source/booster_train/booster_train/tasks/manager_based/locomotion/robots/k1/unitree_velocity/ppo_cfg.py
@@ -1,0 +1,31 @@
+from isaaclab.utils import configclass
+from isaaclab_rl.rsl_rl import RslRlOnPolicyRunnerCfg, RslRlPpoActorCriticCfg, RslRlPpoAlgorithmCfg
+
+
+@configclass
+class PPORunnerCfg(RslRlOnPolicyRunnerCfg):
+    num_steps_per_env = 24
+    max_iterations = 50000
+    save_interval = 100
+    experiment_name = "k1_unitree_velocity"
+    empirical_normalization = False
+    policy = RslRlPpoActorCriticCfg(
+        init_noise_std=1.0,
+        actor_hidden_dims=[512, 256, 128],
+        critic_hidden_dims=[512, 256, 128],
+        activation="elu",
+    )
+    algorithm = RslRlPpoAlgorithmCfg(
+        value_loss_coef=1.0,
+        use_clipped_value_loss=True,
+        clip_param=0.2,
+        entropy_coef=0.01,
+        num_learning_epochs=5,
+        num_mini_batches=4,
+        learning_rate=1.0e-3,
+        schedule="adaptive",
+        gamma=0.99,
+        lam=0.95,
+        desired_kl=0.01,
+        max_grad_norm=1.0,
+    )

--- a/source/booster_train/booster_train/tasks/manager_based/locomotion/robots/k1/walk/__init__.py
+++ b/source/booster_train/booster_train/tasks/manager_based/locomotion/robots/k1/walk/__init__.py
@@ -1,8 +1,3 @@
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import gymnasium as gym
 
 

--- a/source/booster_train/booster_train/tasks/manager_based/locomotion/robots/k1/walk/__init__.py
+++ b/source/booster_train/booster_train/tasks/manager_based/locomotion/robots/k1/walk/__init__.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import gymnasium as gym
+
+
+gym.register(
+    id="Booster-K1-Locomotion-v0",
+    entry_point="isaaclab.envs:ManagerBasedRLEnv",
+    disable_env_checker=True,
+    kwargs={
+        "env_cfg_entry_point": f"{__name__}.env_cfg:FlatEnvCfg",
+        "rsl_rl_cfg_entry_point": f"{__name__}.ppo_cfg:PPORunnerCfg",
+    },
+)
+
+gym.register(
+    id="Booster-K1-Locomotion-v0-Play",
+    entry_point="isaaclab.envs:ManagerBasedRLEnv",
+    disable_env_checker=True,
+    kwargs={
+        "env_cfg_entry_point": f"{__name__}.env_cfg:PlayFlatEnvCfg",
+        "rsl_rl_cfg_entry_point": f"{__name__}.ppo_cfg:PPORunnerCfg",
+    },
+)

--- a/source/booster_train/booster_train/tasks/manager_based/locomotion/robots/k1/walk/__init__.py
+++ b/source/booster_train/booster_train/tasks/manager_based/locomotion/robots/k1/walk/__init__.py
@@ -20,3 +20,43 @@ gym.register(
         "rsl_rl_cfg_entry_point": f"{__name__}.ppo_cfg:PPORunnerCfg",
     },
 )
+
+gym.register(
+    id="Booster-K1-Locomotion-IdealFlatForward-v0",
+    entry_point="isaaclab.envs:ManagerBasedRLEnv",
+    disable_env_checker=True,
+    kwargs={
+        "env_cfg_entry_point": f"{__name__}.env_cfg:IdealFlatForwardEnvCfg",
+        "rsl_rl_cfg_entry_point": f"{__name__}.ppo_cfg:IdealFlatForwardPPORunnerCfg",
+    },
+)
+
+gym.register(
+    id="Booster-K1-Locomotion-IdealFlatForward-v0-Play",
+    entry_point="isaaclab.envs:ManagerBasedRLEnv",
+    disable_env_checker=True,
+    kwargs={
+        "env_cfg_entry_point": f"{__name__}.env_cfg:IdealFlatForwardPlayEnvCfg",
+        "rsl_rl_cfg_entry_point": f"{__name__}.ppo_cfg:IdealFlatForwardPPORunnerCfg",
+    },
+)
+
+gym.register(
+    id="Booster-K1-Locomotion-IdealFlatCommandRandom-v0",
+    entry_point="isaaclab.envs:ManagerBasedRLEnv",
+    disable_env_checker=True,
+    kwargs={
+        "env_cfg_entry_point": f"{__name__}.env_cfg:IdealFlatCommandRandomEnvCfg",
+        "rsl_rl_cfg_entry_point": f"{__name__}.ppo_cfg:IdealFlatCommandRandomPPORunnerCfg",
+    },
+)
+
+gym.register(
+    id="Booster-K1-Locomotion-IdealFlatCommandRandom-v0-Play",
+    entry_point="isaaclab.envs:ManagerBasedRLEnv",
+    disable_env_checker=True,
+    kwargs={
+        "env_cfg_entry_point": f"{__name__}.env_cfg:IdealFlatCommandRandomPlayEnvCfg",
+        "rsl_rl_cfg_entry_point": f"{__name__}.ppo_cfg:IdealFlatCommandRandomPPORunnerCfg",
+    },
+)

--- a/source/booster_train/booster_train/tasks/manager_based/locomotion/robots/k1/walk/env_cfg.py
+++ b/source/booster_train/booster_train/tasks/manager_based/locomotion/robots/k1/walk/env_cfg.py
@@ -223,8 +223,8 @@ class ObservationsCfg:
 
     @configclass
     class CriticCfg(ObsGroup):
-        legged_lab_critic_obs = ObsTerm(
-            func=mdp.k1_legged_lab_critic_observation,
+        privileged_locomotion_obs = ObsTerm(
+            func=mdp.k1_privileged_locomotion_observation,
             params={
                 "command_name": "base_velocity",
                 "asset_cfg": SceneEntityCfg(
@@ -314,7 +314,7 @@ class EventCfg:
 
 @configclass
 class RewardsCfg:
-    """LeggedLab/T1-style reward terms for K1 deploy-compatible locomotion."""
+    """Reward terms for K1 deploy-compatible locomotion."""
 
     track_lin_vel_xy_exp = RewTerm(
         func=mdp.track_lin_vel_xy_yaw_frame_exp,
@@ -548,4 +548,6 @@ class PlayFlatEnvCfg(FlatEnvCfg):
         self.scene.env_spacing = 2.5
         self.events.physics_material = None
         self.events.add_base_mass = None
+        self.events.reset_base = None
+        self.events.reset_robot_joints = None
         self.events.push_robot = None

--- a/source/booster_train/booster_train/tasks/manager_based/locomotion/robots/k1/walk/env_cfg.py
+++ b/source/booster_train/booster_train/tasks/manager_based/locomotion/robots/k1/walk/env_cfg.py
@@ -1,0 +1,556 @@
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from __future__ import annotations
+
+from dataclasses import MISSING
+
+import isaaclab.sim as sim_utils
+from isaaclab.assets import ArticulationCfg, AssetBaseCfg
+from isaaclab.envs import ManagerBasedRLEnvCfg
+from isaaclab.managers import EventTermCfg as EventTerm
+from isaaclab.managers import ObservationGroupCfg as ObsGroup
+from isaaclab.managers import ObservationTermCfg as ObsTerm
+from isaaclab.managers import RewardTermCfg as RewTerm
+from isaaclab.managers import SceneEntityCfg
+from isaaclab.managers import TerminationTermCfg as DoneTerm
+from isaaclab.scene import InteractiveSceneCfg
+from isaaclab.sensors import ContactSensorCfg
+from isaaclab.terrains import TerrainImporterCfg
+from isaaclab.utils import configclass
+from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
+
+from booster_train.assets.robots.booster import BOOSTER_K1_CFG
+import booster_train.tasks.manager_based.locomotion.mdp as mdp
+
+
+K1_WALK_ACTION_SCALE = 0.25
+K1_WALK_OBS_DOF_VEL_SCALE = 0.1
+K1_WALK_OBSERVATION_HISTORY_LENGTH = 10
+K1_WALK_SINGLE_FRAME_OBSERVATION_DIM = 69
+K1_WALK_EXPORTED_OBSERVATION_DIM = 690
+
+K1_WALK_POLICY_JOINT_NAMES = [
+    "ALeft_Shoulder_Pitch",
+    "ARight_Shoulder_Pitch",
+    "Left_Hip_Pitch",
+    "Right_Hip_Pitch",
+    "Left_Shoulder_Roll",
+    "Right_Shoulder_Roll",
+    "Left_Hip_Roll",
+    "Right_Hip_Roll",
+    "Left_Elbow_Pitch",
+    "Right_Elbow_Pitch",
+    "Left_Hip_Yaw",
+    "Right_Hip_Yaw",
+    "Left_Elbow_Yaw",
+    "Right_Elbow_Yaw",
+    "Left_Knee_Pitch",
+    "Right_Knee_Pitch",
+    "Left_Ankle_Pitch",
+    "Right_Ankle_Pitch",
+    "Left_Ankle_Roll",
+    "Right_Ankle_Roll",
+]
+
+K1_REAL_JOINT_NAMES = [
+    "AAHead_yaw",
+    "Head_pitch",
+    "ALeft_Shoulder_Pitch",
+    "Left_Shoulder_Roll",
+    "Left_Elbow_Pitch",
+    "Left_Elbow_Yaw",
+    "ARight_Shoulder_Pitch",
+    "Right_Shoulder_Roll",
+    "Right_Elbow_Pitch",
+    "Right_Elbow_Yaw",
+    "Left_Hip_Pitch",
+    "Left_Hip_Roll",
+    "Left_Hip_Yaw",
+    "Left_Knee_Pitch",
+    "Left_Ankle_Pitch",
+    "Left_Ankle_Roll",
+    "Right_Hip_Pitch",
+    "Right_Hip_Roll",
+    "Right_Hip_Yaw",
+    "Right_Knee_Pitch",
+    "Right_Ankle_Pitch",
+    "Right_Ankle_Roll",
+]
+
+K1_WALK_DEFAULT_JOINT_POS = [
+    0.0,
+    0.0,
+    0.2,
+    -1.25,
+    0.0,
+    -0.5,
+    0.2,
+    1.25,
+    0.0,
+    0.5,
+    -0.15,
+    0.0,
+    0.0,
+    0.3,
+    -0.15,
+    0.0,
+    -0.15,
+    0.0,
+    0.0,
+    0.3,
+    -0.15,
+    0.0,
+]
+
+K1_WALK_DEFAULT_JOINT_POS_BY_NAME = dict(zip(K1_REAL_JOINT_NAMES, K1_WALK_DEFAULT_JOINT_POS))
+
+K1_WALK_FOOT_BODY_NAMES = ["left_foot_link", "right_foot_link"]
+K1_WALK_ARM_JOINT_NAMES = [
+    "ALeft_Shoulder_Pitch",
+    "ARight_Shoulder_Pitch",
+    "Left_Shoulder_Roll",
+    "Right_Shoulder_Roll",
+    "Left_Elbow_Pitch",
+    "Right_Elbow_Pitch",
+    "Left_Elbow_Yaw",
+    "Right_Elbow_Yaw",
+]
+K1_WALK_ARM_ACTION_INDICES = [
+    K1_WALK_POLICY_JOINT_NAMES.index(name) for name in K1_WALK_ARM_JOINT_NAMES
+]
+K1_WALK_LEG_JOINT_NAMES = [
+    ".*_Hip_Pitch",
+    ".*_Hip_Roll",
+    ".*_Hip_Yaw",
+    ".*_Knee_Pitch",
+    ".*_Ankle_Pitch",
+    ".*_Ankle_Roll",
+]
+
+
+@configclass
+class K1WalkSceneCfg(InteractiveSceneCfg):
+    """Configuration for the K1 flat locomotion scene."""
+
+    terrain = TerrainImporterCfg(
+        prim_path="/World/ground",
+        terrain_type="plane",
+        collision_group=-1,
+        physics_material=sim_utils.RigidBodyMaterialCfg(
+            friction_combine_mode="multiply",
+            restitution_combine_mode="multiply",
+            static_friction=1.0,
+            dynamic_friction=1.0,
+        ),
+        visual_material=sim_utils.MdlFileCfg(
+            mdl_path=f"{ISAAC_NUCLEUS_DIR}/Materials/Base/Architecture/Shingles_01.mdl",
+            project_uvw=True,
+        ),
+    )
+    robot: ArticulationCfg = MISSING
+    contact_forces = ContactSensorCfg(
+        prim_path="{ENV_REGEX_NS}/Robot/.*",
+        history_length=3,
+        track_air_time=True,
+        force_threshold=10.0,
+        debug_vis=False,
+    )
+    light = AssetBaseCfg(
+        prim_path="/World/light",
+        spawn=sim_utils.DistantLightCfg(color=(0.75, 0.75, 0.75), intensity=3000.0),
+    )
+    sky_light = AssetBaseCfg(
+        prim_path="/World/skyLight",
+        spawn=sim_utils.DomeLightCfg(color=(0.13, 0.13, 0.13), intensity=1000.0),
+    )
+
+
+@configclass
+class CommandsCfg:
+    """Command specifications for the MDP."""
+
+    base_velocity = mdp.UniformVelocityCommandCfg(
+        asset_name="robot",
+        resampling_time_range=(10.0, 10.0),
+        rel_standing_envs=0.2,
+        rel_heading_envs=0.0,
+        heading_command=False,
+        debug_vis=True,
+        ranges=mdp.UniformVelocityCommandCfg.Ranges(
+            lin_vel_x=(-1.0, 1.0),
+            lin_vel_y=(-1.0, 1.0),
+            ang_vel_z=(-1.0, 1.0),
+        ),
+    )
+
+
+@configclass
+class ActionsCfg:
+    """Action specifications for the MDP."""
+
+    joint_pos = mdp.JointPositionActionCfg(
+        asset_name="robot",
+        joint_names=K1_WALK_POLICY_JOINT_NAMES,
+        scale=K1_WALK_ACTION_SCALE,
+        use_default_offset=True,
+        preserve_order=True,
+    )
+
+
+@configclass
+class ObservationsCfg:
+    """Observation specifications for the MDP."""
+
+    @configclass
+    class PolicyCfg(ObsGroup):
+        deploy_locomotion_obs = ObsTerm(
+            func=mdp.k1_deploy_locomotion_observation,
+            params={
+                "command_name": "base_velocity",
+                "asset_cfg": SceneEntityCfg(
+                    "robot",
+                    joint_names=K1_WALK_POLICY_JOINT_NAMES,
+                    preserve_order=True,
+                ),
+                "obs_dof_vel_scale": K1_WALK_OBS_DOF_VEL_SCALE,
+            },
+            clip=(-100.0, 100.0),
+            history_length=K1_WALK_OBSERVATION_HISTORY_LENGTH,
+            flatten_history_dim=True,
+        )
+
+        def __post_init__(self):
+            self.enable_corruption = False
+            self.concatenate_terms = True
+
+    @configclass
+    class CriticCfg(ObsGroup):
+        legged_lab_critic_obs = ObsTerm(
+            func=mdp.k1_legged_lab_critic_observation,
+            params={
+                "command_name": "base_velocity",
+                "asset_cfg": SceneEntityCfg(
+                    "robot",
+                    joint_names=K1_WALK_POLICY_JOINT_NAMES,
+                    preserve_order=True,
+                ),
+                "sensor_cfg": SceneEntityCfg(
+                    "contact_forces",
+                    body_names=K1_WALK_FOOT_BODY_NAMES,
+                    preserve_order=True,
+                ),
+                "obs_dof_vel_scale": K1_WALK_OBS_DOF_VEL_SCALE,
+                "contact_threshold": 0.5,
+            },
+            clip=(-100.0, 100.0),
+            history_length=K1_WALK_OBSERVATION_HISTORY_LENGTH,
+            flatten_history_dim=True,
+        )
+
+        def __post_init__(self):
+            self.enable_corruption = False
+            self.concatenate_terms = True
+
+    policy: PolicyCfg = PolicyCfg()
+    critic: CriticCfg = CriticCfg()
+
+
+@configclass
+class EventCfg:
+    """Configuration for events."""
+
+    physics_material = EventTerm(
+        func=mdp.randomize_rigid_body_material,
+        mode="startup",
+        params={
+            "asset_cfg": SceneEntityCfg("robot", body_names=".*"),
+            "static_friction_range": (0.6, 1.0),
+            "dynamic_friction_range": (0.4, 0.8),
+            "restitution_range": (0.0, 0.005),
+            "num_buckets": 64,
+        },
+    )
+
+    add_base_mass = EventTerm(
+        func=mdp.randomize_rigid_body_mass,
+        mode="startup",
+        params={
+            "asset_cfg": SceneEntityCfg("robot", body_names="Trunk"),
+            "mass_distribution_params": (-5.0, 5.0),
+            "operation": "add",
+        },
+    )
+
+    reset_base = EventTerm(
+        func=mdp.reset_root_state_uniform,
+        mode="reset",
+        params={
+            "pose_range": {"x": (-0.5, 0.5), "y": (-0.5, 0.5), "yaw": (-3.14, 3.14)},
+            "velocity_range": {
+                "x": (-0.5, 0.5),
+                "y": (-0.5, 0.5),
+                "z": (-0.5, 0.5),
+                "roll": (-0.5, 0.5),
+                "pitch": (-0.5, 0.5),
+                "yaw": (-0.5, 0.5),
+            },
+        },
+    )
+
+    reset_robot_joints = EventTerm(
+        func=mdp.reset_joints_by_scale,
+        mode="reset",
+        params={
+            "position_range": (0.5, 1.5),
+            "velocity_range": (0.0, 0.0),
+        },
+    )
+
+    push_robot = EventTerm(
+        func=mdp.push_by_setting_velocity,
+        mode="interval",
+        interval_range_s=(10.0, 15.0),
+        params={"velocity_range": {"x": (-1.0, 1.0), "y": (-1.0, 1.0)}},
+    )
+
+
+@configclass
+class RewardsCfg:
+    """LeggedLab/T1-style reward terms for K1 deploy-compatible locomotion."""
+
+    track_lin_vel_xy_exp = RewTerm(
+        func=mdp.track_lin_vel_xy_yaw_frame_exp,
+        weight=1.0,
+        params={"command_name": "base_velocity", "std": 0.5},
+    )
+    track_ang_vel_z_exp = RewTerm(
+        func=mdp.track_ang_vel_z_world_exp,
+        weight=1.0,
+        params={"command_name": "base_velocity", "std": 0.5},
+    )
+    lin_vel_z_l2 = RewTerm(func=mdp.lin_vel_z_l2, weight=-1.0)
+    ang_vel_xy_l2 = RewTerm(func=mdp.ang_vel_xy_l2, weight=-0.05)
+    energy = RewTerm(
+        func=mdp.k1_joint_energy,
+        weight=-1.0e-3,
+        params={
+            "asset_cfg": SceneEntityCfg(
+                "robot",
+                joint_names=K1_WALK_POLICY_JOINT_NAMES,
+                preserve_order=True,
+            )
+        },
+    )
+    joint_torques_l2 = RewTerm(
+        func=mdp.k1_joint_torques_l2,
+        weight=-2.0e-6,
+        params={
+            "asset_cfg": SceneEntityCfg(
+                "robot",
+                joint_names=K1_WALK_POLICY_JOINT_NAMES,
+                preserve_order=True,
+            )
+        },
+    )
+    dof_acc_l2 = RewTerm(
+        func=mdp.joint_acc_l2,
+        weight=-1.25e-7,
+        params={
+            "asset_cfg": SceneEntityCfg(
+                "robot",
+                joint_names=K1_WALK_POLICY_JOINT_NAMES,
+                preserve_order=True,
+            )
+        },
+    )
+    action_rate_l2 = RewTerm(func=mdp.action_rate_l2, weight=-0.01)
+    arm_joint_deviation_l1 = RewTerm(
+        func=mdp.joint_deviation_l1,
+        weight=-0.2,
+        params={
+            "asset_cfg": SceneEntityCfg(
+                "robot",
+                joint_names=K1_WALK_ARM_JOINT_NAMES,
+                preserve_order=True,
+            )
+        },
+    )
+    arm_action_l2 = RewTerm(
+        func=mdp.action_l2_subset,
+        weight=-0.03,
+        params={"action_indices": K1_WALK_ARM_ACTION_INDICES},
+    )
+    arm_action_rate_l2 = RewTerm(
+        func=mdp.action_rate_l2_subset,
+        weight=-0.02,
+        params={"action_indices": K1_WALK_ARM_ACTION_INDICES},
+    )
+    flat_orientation_l2 = RewTerm(func=mdp.flat_orientation_l2, weight=-1.0)
+    termination_penalty = RewTerm(func=mdp.is_terminated, weight=-200.0)
+    feet_air_time = RewTerm(
+        func=mdp.feet_air_time_positive_biped,
+        weight=0.5,
+        params={
+            "sensor_cfg": SceneEntityCfg(
+                "contact_forces",
+                body_names=K1_WALK_FOOT_BODY_NAMES,
+                preserve_order=True,
+            ),
+            "command_name": "base_velocity",
+            "threshold": 0.4,
+        },
+    )
+    feet_slide = RewTerm(
+        func=mdp.feet_slide,
+        weight=-0.25,
+        params={
+            "sensor_cfg": SceneEntityCfg(
+                "contact_forces",
+                body_names=K1_WALK_FOOT_BODY_NAMES,
+                preserve_order=True,
+            ),
+            "asset_cfg": SceneEntityCfg(
+                "robot",
+                body_names=K1_WALK_FOOT_BODY_NAMES,
+                preserve_order=True,
+            ),
+        },
+    )
+    feet_force = RewTerm(
+        func=mdp.k1_body_force,
+        weight=-3.0e-3,
+        params={
+            "sensor_cfg": SceneEntityCfg(
+                "contact_forces",
+                body_names=K1_WALK_FOOT_BODY_NAMES,
+                preserve_order=True,
+            ),
+            "threshold": 500.0,
+            "max_reward": 400.0,
+        },
+    )
+    feet_too_near = RewTerm(
+        func=mdp.k1_feet_too_near_humanoid,
+        weight=-2.0,
+        params={
+            "threshold": 0.2,
+            "asset_cfg": SceneEntityCfg(
+                "robot",
+                body_names=K1_WALK_FOOT_BODY_NAMES,
+                preserve_order=True,
+            ),
+        },
+    )
+    feet_stumble = RewTerm(
+        func=mdp.k1_feet_stumble,
+        weight=-2.0,
+        params={
+            "sensor_cfg": SceneEntityCfg(
+                "contact_forces",
+                body_names=K1_WALK_FOOT_BODY_NAMES,
+                preserve_order=True,
+            )
+        },
+    )
+    dof_pos_limits = RewTerm(
+        func=mdp.joint_pos_limits,
+        weight=-2.0,
+        params={
+            "asset_cfg": SceneEntityCfg(
+                "robot",
+                joint_names=K1_WALK_POLICY_JOINT_NAMES,
+                preserve_order=True,
+            )
+        },
+    )
+    undesired_contacts = RewTerm(
+        func=mdp.undesired_contacts,
+        weight=-1.0,
+        params={
+            "sensor_cfg": SceneEntityCfg(
+                "contact_forces",
+                body_names=[r"^(?!left_foot_link$)(?!right_foot_link$).+$"],
+            ),
+            "threshold": 1.0,
+        },
+    )
+
+
+@configclass
+class TerminationsCfg:
+    """Termination terms for the MDP."""
+
+    time_out = DoneTerm(func=mdp.time_out, time_out=True)
+    base_contact = DoneTerm(
+        func=mdp.illegal_contact,
+        params={"sensor_cfg": SceneEntityCfg("contact_forces", body_names="Trunk"), "threshold": 1.0},
+    )
+    bad_orientation = DoneTerm(func=mdp.bad_orientation, params={"limit_angle": 0.8})
+
+
+@configclass
+class CurriculumCfg:
+    """Curriculum terms for the MDP."""
+
+    pass
+
+
+@configclass
+class FlatEnvCfg(ManagerBasedRLEnvCfg):
+    """Flat-terrain K1 velocity-tracking environment."""
+
+    scene: K1WalkSceneCfg = K1WalkSceneCfg(num_envs=4096, env_spacing=2.5)
+    observations: ObservationsCfg = ObservationsCfg()
+    actions: ActionsCfg = ActionsCfg()
+    commands: CommandsCfg = CommandsCfg()
+    rewards: RewardsCfg = RewardsCfg()
+    terminations: TerminationsCfg = TerminationsCfg()
+    events: EventCfg = EventCfg()
+    curriculum: CurriculumCfg = CurriculumCfg()
+
+    action_scale = K1_WALK_ACTION_SCALE
+    action_joint_names = K1_WALK_POLICY_JOINT_NAMES
+    observation_history_length = K1_WALK_OBSERVATION_HISTORY_LENGTH
+    single_frame_observation_dim = K1_WALK_SINGLE_FRAME_OBSERVATION_DIM
+    exported_observation_dim = K1_WALK_EXPORTED_OBSERVATION_DIM
+
+    def __post_init__(self):
+        """Post initialization."""
+        self.scene.robot = BOOSTER_K1_CFG.replace(
+            prim_path="{ENV_REGEX_NS}/Robot",
+            init_state=ArticulationCfg.InitialStateCfg(
+                pos=(0.0, 0.0, 0.57),
+                joint_pos=K1_WALK_DEFAULT_JOINT_POS_BY_NAME,
+                joint_vel={".*": 0.0},
+            ),
+        )
+
+        self.decimation = 4
+        self.episode_length_s = 20.0
+        self.sim.dt = 0.005
+        self.sim.render_interval = self.decimation
+        self.sim.physics_material = self.scene.terrain.physics_material
+        self.sim.physx.gpu_max_rigid_patch_count = 10 * 2**15
+        self.viewer.origin_type = "world"
+        self.viewer.eye = (3.0, -4.0, 2.0)
+        self.viewer.lookat = (0.0, 0.0, 1.0)
+
+        if self.scene.contact_forces is not None:
+            self.scene.contact_forces.update_period = self.sim.dt
+
+
+@configclass
+class PlayFlatEnvCfg(FlatEnvCfg):
+    """Reduced K1 locomotion environment for play/export."""
+
+    def __post_init__(self):
+        super().__post_init__()
+
+        self.scene.num_envs = 50
+        self.scene.env_spacing = 2.5
+        self.events.physics_material = None
+        self.events.add_base_mass = None
+        self.events.push_robot = None

--- a/source/booster_train/booster_train/tasks/manager_based/locomotion/robots/k1/walk/env_cfg.py
+++ b/source/booster_train/booster_train/tasks/manager_based/locomotion/robots/k1/walk/env_cfg.py
@@ -5,6 +5,7 @@ from dataclasses import MISSING
 import isaaclab.sim as sim_utils
 from isaaclab.assets import ArticulationCfg, AssetBaseCfg
 from isaaclab.envs import ManagerBasedRLEnvCfg
+from isaaclab.managers import CurriculumTermCfg as CurrTerm
 from isaaclab.managers import EventTermCfg as EventTerm
 from isaaclab.managers import ObservationGroupCfg as ObsGroup
 from isaaclab.managers import ObservationTermCfg as ObsTerm
@@ -494,6 +495,16 @@ class CurriculumCfg:
 
 
 @configclass
+class IdealFlatForwardCurriculumCfg(CurriculumCfg):
+    """Reset-time metrics for the fixed-forward ideal flat check."""
+
+    flat_forward_metrics = CurrTerm(
+        func=mdp.k1_flat_forward_metrics,
+        params={"command_name": "base_velocity", "asset_cfg": SceneEntityCfg("robot")},
+    )
+
+
+@configclass
 class FlatEnvCfg(ManagerBasedRLEnvCfg):
     """Flat-terrain K1 velocity-tracking environment."""
 
@@ -551,3 +562,71 @@ class PlayFlatEnvCfg(FlatEnvCfg):
         self.events.reset_base = None
         self.events.reset_robot_joints = None
         self.events.push_robot = None
+
+
+@configclass
+class IdealFlatForwardEnvCfg(FlatEnvCfg):
+    """Minimal fixed-forward K1 locomotion environment."""
+
+    curriculum: IdealFlatForwardCurriculumCfg = IdealFlatForwardCurriculumCfg()
+
+    def __post_init__(self):
+        super().__post_init__()
+
+        self.events.physics_material = None
+        self.events.add_base_mass = None
+        self.events.push_robot = None
+        self.events.reset_base.params["pose_range"] = {"x": (0.0, 0.0), "y": (0.0, 0.0), "yaw": (0.0, 0.0)}
+        self.events.reset_base.params["velocity_range"] = {
+            "x": (0.0, 0.0),
+            "y": (0.0, 0.0),
+            "z": (0.0, 0.0),
+            "roll": (0.0, 0.0),
+            "pitch": (0.0, 0.0),
+            "yaw": (0.0, 0.0),
+        }
+        self.events.reset_robot_joints.params["position_range"] = (1.0, 1.0)
+        self.events.reset_robot_joints.params["velocity_range"] = (0.0, 0.0)
+
+        self.commands.base_velocity.debug_vis = False
+        self.commands.base_velocity.rel_standing_envs = 0.0
+        self.commands.base_velocity.rel_heading_envs = 0.0
+        self.commands.base_velocity.heading_command = False
+        self.commands.base_velocity.ranges.lin_vel_x = (0.3, 0.3)
+        self.commands.base_velocity.ranges.lin_vel_y = (0.0, 0.0)
+        self.commands.base_velocity.ranges.ang_vel_z = (0.0, 0.0)
+
+
+@configclass
+class IdealFlatForwardPlayEnvCfg(IdealFlatForwardEnvCfg):
+    """Single-environment play/export variant of the ideal flat-forward task."""
+
+    def __post_init__(self):
+        super().__post_init__()
+        self.scene.num_envs = 1
+
+
+@configclass
+class IdealFlatCommandRandomEnvCfg(IdealFlatForwardEnvCfg):
+    """Ideal flat K1 locomotion environment with the original randomized command distribution."""
+
+    def __post_init__(self):
+        super().__post_init__()
+
+        self.commands.base_velocity.resampling_time_range = (10.0, 10.0)
+        self.commands.base_velocity.debug_vis = True
+        self.commands.base_velocity.rel_standing_envs = 0.2
+        self.commands.base_velocity.rel_heading_envs = 0.0
+        self.commands.base_velocity.heading_command = False
+        self.commands.base_velocity.ranges.lin_vel_x = (-1.0, 1.0)
+        self.commands.base_velocity.ranges.lin_vel_y = (-1.0, 1.0)
+        self.commands.base_velocity.ranges.ang_vel_z = (-1.0, 1.0)
+
+
+@configclass
+class IdealFlatCommandRandomPlayEnvCfg(IdealFlatCommandRandomEnvCfg):
+    """Single-environment play/export variant of the command-random ideal flat task."""
+
+    def __post_init__(self):
+        super().__post_init__()
+        self.scene.num_envs = 1

--- a/source/booster_train/booster_train/tasks/manager_based/locomotion/robots/k1/walk/env_cfg.py
+++ b/source/booster_train/booster_train/tasks/manager_based/locomotion/robots/k1/walk/env_cfg.py
@@ -1,8 +1,3 @@
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 from dataclasses import MISSING

--- a/source/booster_train/booster_train/tasks/manager_based/locomotion/robots/k1/walk/ppo_cfg.py
+++ b/source/booster_train/booster_train/tasks/manager_based/locomotion/robots/k1/walk/ppo_cfg.py
@@ -4,7 +4,7 @@ from isaaclab_rl.rsl_rl import RslRlOnPolicyRunnerCfg, RslRlPpoActorCriticCfg, R
 
 @configclass
 class PPORunnerCfg(RslRlOnPolicyRunnerCfg):
-    """LeggedLab/T1-style PPO recipe for K1 deploy-compatible locomotion."""
+    """PPO runner configuration for K1 deploy-compatible locomotion."""
 
     seed = 42
     num_steps_per_env = 24

--- a/source/booster_train/booster_train/tasks/manager_based/locomotion/robots/k1/walk/ppo_cfg.py
+++ b/source/booster_train/booster_train/tasks/manager_based/locomotion/robots/k1/walk/ppo_cfg.py
@@ -33,3 +33,17 @@ class PPORunnerCfg(RslRlOnPolicyRunnerCfg):
         desired_kl=0.01,
         max_grad_norm=1.0,
     )
+
+
+@configclass
+class IdealFlatForwardPPORunnerCfg(PPORunnerCfg):
+    """PPO runner configuration for the ideal flat-forward K1 check."""
+
+    experiment_name = "k1_locomotion_ideal_flat_forward"
+
+
+@configclass
+class IdealFlatCommandRandomPPORunnerCfg(PPORunnerCfg):
+    """PPO runner configuration for the ideal flat command-random K1 check."""
+
+    experiment_name = "k1_locomotion_ideal_flat_command_random"

--- a/source/booster_train/booster_train/tasks/manager_based/locomotion/robots/k1/walk/ppo_cfg.py
+++ b/source/booster_train/booster_train/tasks/manager_based/locomotion/robots/k1/walk/ppo_cfg.py
@@ -1,8 +1,3 @@
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from isaaclab.utils import configclass
 from isaaclab_rl.rsl_rl import RslRlOnPolicyRunnerCfg, RslRlPpoActorCriticCfg, RslRlPpoAlgorithmCfg
 

--- a/source/booster_train/booster_train/tasks/manager_based/locomotion/robots/k1/walk/ppo_cfg.py
+++ b/source/booster_train/booster_train/tasks/manager_based/locomotion/robots/k1/walk/ppo_cfg.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from isaaclab.utils import configclass
+from isaaclab_rl.rsl_rl import RslRlOnPolicyRunnerCfg, RslRlPpoActorCriticCfg, RslRlPpoAlgorithmCfg
+
+
+@configclass
+class PPORunnerCfg(RslRlOnPolicyRunnerCfg):
+    """LeggedLab/T1-style PPO recipe for K1 deploy-compatible locomotion."""
+
+    seed = 42
+    num_steps_per_env = 24
+    max_iterations = 50000
+    save_interval = 100
+    experiment_name = "k1_locomotion"
+    empirical_normalization = True
+    clip_actions = None
+    policy = RslRlPpoActorCriticCfg(
+        init_noise_std=1.0,
+        actor_hidden_dims=[512, 256, 128],
+        critic_hidden_dims=[512, 256, 128],
+        activation="elu",
+    )
+    algorithm = RslRlPpoAlgorithmCfg(
+        value_loss_coef=1.0,
+        use_clipped_value_loss=True,
+        clip_param=0.2,
+        entropy_coef=0.005,
+        num_learning_epochs=5,
+        num_mini_batches=4,
+        learning_rate=1.0e-3,
+        schedule="adaptive",
+        gamma=0.99,
+        lam=0.95,
+        desired_kl=0.01,
+        max_grad_norm=1.0,
+    )


### PR DESCRIPTION
## Summary

This PR adds an Isaac Lab / RSL-RL based locomotion task so that a velocity-commanded K1 walking policy can be trained in `booster_train`.

The following tasks are registered:

- `Booster-K1-Locomotion-v0`
- `Booster-K1-Locomotion-v0-Play`

A corresponding `booster_deploy` PR has also been created so policies exported from this task can run on the deploy side:

- https://github.com/BoosterRobotics/booster_deploy/pull/6

## Structure

The implementation follows the same organization pattern as the existing BeyondMimic tasks by separating the task family, shared MDP components, and robot-specific configuration.

- `tasks/manager_based/locomotion/`
  - Package for velocity-commanded locomotion tasks.
  - This is separate from `beyond_mimic/` so reference-motion tracking tasks and velocity locomotion tasks do not share the same task package.

- `tasks/manager_based/locomotion/mdp/`
  - Locomotion-specific MDP extensions.
  - Command and event logic reuse the standard Isaac Lab velocity-locomotion MDP. Only the observation and reward helpers needed for K1 and deploy compatibility are added here.

- `tasks/manager_based/locomotion/robots/k1/walk/`
  - K1-specific walking task configuration.
  - Contains Gym registration for `Booster-K1-Locomotion-v0` and `Booster-K1-Locomotion-v0-Play`, K1 joint ordering, action and observation settings, reward weights, and PPO settings.

This matches the existing hierarchy used by tasks such as `beyond_mimic/robots/k1/fight_001/` and `beyond_mimic/robots/k1/mj_dance_002/`.

The locomotion task also reuses the standard Isaac Lab velocity-locomotion MDP:

```python
from isaaclab_tasks.manager_based.locomotion.velocity.mdp import *
```

BeyondMimic tracks reference motions from `.npz` files, so it needs custom components such as `MotionLoader`, `MotionCommand`, intermediate-frame reset, adaptive sampling, motion-tracking rewards, and motion-deviation termination.

This PR adds a standard velocity-commanded walking task, so it uses the existing velocity-locomotion MDP as the base and only adds the K1-specific and deploy-compatible pieces.

## Description

This PR adds a task for training a K1 walking policy compatible with `booster_deploy.tasks.locomotion.K1WalkControllerCfg`.

The actor observation is aligned with the deploy-side input contract:

```text
base_ang_vel(3)
+ projected_gravity(3)
+ velocity_command(3)
+ joint_pos_rel(20)
+ joint_vel(20) * 0.1
+ last_action(20)
= 69
```

This single-frame observation is stacked over a 10-frame history, so the exported actor input dimension is 690.

The action space controls 20 of K1's 22 DoF, excluding the two head joints. The joint order is fixed to remain compatible with `K1WalkControllerCfg`:

```text
ALeft_Shoulder_Pitch
ARight_Shoulder_Pitch
Left_Hip_Pitch
Right_Hip_Pitch
Left_Shoulder_Roll
Right_Shoulder_Roll
Left_Hip_Roll
Right_Hip_Roll
Left_Elbow_Pitch
Right_Elbow_Pitch
Left_Hip_Yaw
Right_Hip_Yaw
Left_Elbow_Yaw
Right_Elbow_Yaw
Left_Knee_Pitch
Right_Knee_Pitch
Left_Ankle_Pitch
Right_Ankle_Pitch
Left_Ankle_Roll
Right_Ankle_Roll
```

The reward design focuses on the terms needed for a velocity-commanded walking policy: velocity tracking, posture stabilization, contacts, joint limits, and motion smoothness. The main terms are:

- linear velocity tracking in x/y
- yaw angular velocity tracking
- posture stabilization
- suppression of vertical velocity and roll/pitch angular velocity
- energy / torque / acceleration penalties
- foot air time
- foot slide / stumble / too-near penalties
- undesired contact penalty
- joint limit penalty

Early training showed a tendency for the arms to spread outward and move unnaturally, so this PR also adds arm-specific regularization terms to make the gait look more natural:

- `arm_joint_deviation_l1`
  - Discourages arm joints from drifting far from the default pose.

- `arm_action_l2`
  - Penalizes large arm actions directly.

- `arm_action_rate_l2`
  - Penalizes rapid changes in arm actions.

These terms apply only to the arm joint/action subset, so they do not overly constrain the leg locomotion behavior.

## Tests

Training was run with the following command:

```bash
python scripts/rsl_rl/train.py \
  --task=Booster-K1-Locomotion-v0 \
  --num_envs=8192 \
  --headless \
  --device cuda:0
```

Playback and policy checks can be run with `Booster-K1-Locomotion-v0-Play`:

```bash
python scripts/rsl_rl/play.py \
  --task=Booster-K1-Locomotion-v0-Play \
  --checkpoint <checkpoint_path> \
  --device cuda:0
```
Training result video:

https://github.com/user-attachments/assets/af4997ce-a6ab-4e61-8580-3f03c4722824


