### PR TITLE
[codex] add K1 locomotion task

### DIFF
--- a/source/booster_train/booster_train/tasks/manager_based/locomotion/__init__.py
+++ b/source/booster_train/booster_train/tasks/manager_based/locomotion/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause

--- a/source/booster_train/booster_train/tasks/manager_based/locomotion/mdp/__init__.py
+++ b/source/booster_train/booster_train/tasks/manager_based/locomotion/mdp/__init__.py
@@ -1,0 +1,11 @@
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""MDP terms for Booster locomotion tasks."""
+
+from isaaclab_tasks.manager_based.locomotion.velocity.mdp import *  # noqa: F401, F403
+
+from .observations import *  # noqa: F401, F403
+from .rewards import *  # noqa: F401, F403

--- a/source/booster_train/booster_train/tasks/manager_based/locomotion/mdp/observations.py
+++ b/source/booster_train/booster_train/tasks/manager_based/locomotion/mdp/observations.py
@@ -43,7 +43,7 @@ def k1_deploy_locomotion_observation(
     )
 
 
-def k1_legged_lab_critic_observation(
+def k1_privileged_locomotion_observation(
     env: ManagerBasedRLEnv,
     command_name: str,
     asset_cfg: SceneEntityCfg,
@@ -51,7 +51,7 @@ def k1_legged_lab_critic_observation(
     obs_dof_vel_scale: float,
     contact_threshold: float,
 ) -> torch.Tensor:
-    """Single-frame privileged critic observation following the LeggedLab locomotion recipe."""
+    """Single-frame privileged critic observation for K1 locomotion training."""
     asset: Articulation = env.scene[asset_cfg.name]
     contact_sensor: ContactSensor = env.scene.sensors[sensor_cfg.name]
     contacts = (

--- a/source/booster_train/booster_train/tasks/manager_based/locomotion/mdp/observations.py
+++ b/source/booster_train/booster_train/tasks/manager_based/locomotion/mdp/observations.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+
+from isaaclab.assets import Articulation
+from isaaclab.managers import SceneEntityCfg
+from isaaclab.sensors import ContactSensor
+
+if TYPE_CHECKING:
+    from isaaclab.envs import ManagerBasedRLEnv
+
+
+def k1_deploy_locomotion_observation(
+    env: ManagerBasedRLEnv,
+    command_name: str,
+    asset_cfg: SceneEntityCfg,
+    obs_dof_vel_scale: float,
+) -> torch.Tensor:
+    """Single-frame observation compatible with deploy K1WalkControllerCfg."""
+    asset: Articulation = env.scene[asset_cfg.name]
+    joint_ids = asset_cfg.joint_ids
+
+    joint_pos_rel = asset.data.joint_pos[:, joint_ids] - asset.data.default_joint_pos[:, joint_ids]
+    joint_vel_scaled = asset.data.joint_vel[:, joint_ids] * obs_dof_vel_scale
+
+    return torch.cat(
+        (
+            asset.data.root_ang_vel_b,
+            asset.data.projected_gravity_b,
+            env.command_manager.get_command(command_name),
+            joint_pos_rel,
+            joint_vel_scaled,
+            env.action_manager.action,
+        ),
+        dim=-1,
+    )
+
+
+def k1_legged_lab_critic_observation(
+    env: ManagerBasedRLEnv,
+    command_name: str,
+    asset_cfg: SceneEntityCfg,
+    sensor_cfg: SceneEntityCfg,
+    obs_dof_vel_scale: float,
+    contact_threshold: float,
+) -> torch.Tensor:
+    """Single-frame privileged critic observation following the LeggedLab locomotion recipe."""
+    asset: Articulation = env.scene[asset_cfg.name]
+    contact_sensor: ContactSensor = env.scene.sensors[sensor_cfg.name]
+    contacts = (
+        contact_sensor.data.net_forces_w_history[:, :, sensor_cfg.body_ids, :].norm(dim=-1).max(dim=1)[0]
+        > contact_threshold
+    )
+
+    policy_obs = k1_deploy_locomotion_observation(
+        env=env,
+        command_name=command_name,
+        asset_cfg=asset_cfg,
+        obs_dof_vel_scale=obs_dof_vel_scale,
+    )
+    return torch.cat((policy_obs, asset.data.root_lin_vel_b, contacts.float()), dim=-1)

--- a/source/booster_train/booster_train/tasks/manager_based/locomotion/mdp/rewards.py
+++ b/source/booster_train/booster_train/tasks/manager_based/locomotion/mdp/rewards.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from __future__ import annotations
+
+import torch
+
+from isaaclab.assets import Articulation
+from isaaclab.managers import SceneEntityCfg
+from isaaclab.sensors import ContactSensor
+
+
+def k1_joint_torques_l2(env, asset_cfg: SceneEntityCfg = SceneEntityCfg("robot")) -> torch.Tensor:
+    asset: Articulation = env.scene[asset_cfg.name]
+    return torch.sum(asset.data.applied_torque[:, asset_cfg.joint_ids].square(), dim=-1)
+
+
+def k1_joint_energy(env, asset_cfg: SceneEntityCfg = SceneEntityCfg("robot")) -> torch.Tensor:
+    asset: Articulation = env.scene[asset_cfg.name]
+    joint_power = torch.abs(
+        asset.data.applied_torque[:, asset_cfg.joint_ids] * asset.data.joint_vel[:, asset_cfg.joint_ids]
+    )
+    return torch.norm(joint_power, dim=-1)
+
+
+def action_l2_subset(env, action_indices: list[int] | tuple[int, ...]) -> torch.Tensor:
+    return torch.sum(torch.square(env.action_manager.action[:, action_indices]), dim=-1)
+
+
+def action_rate_l2_subset(env, action_indices: list[int] | tuple[int, ...]) -> torch.Tensor:
+    action = env.action_manager.action[:, action_indices]
+    prev_action = env.action_manager.prev_action[:, action_indices]
+    return torch.sum(torch.square(action - prev_action), dim=-1)
+
+
+def k1_body_force(env, sensor_cfg: SceneEntityCfg, threshold: float, max_reward: float) -> torch.Tensor:
+    contact_sensor: ContactSensor = env.scene.sensors[sensor_cfg.name]
+    reward = contact_sensor.data.net_forces_w[:, sensor_cfg.body_ids, 2].norm(dim=-1)
+    reward = torch.where(reward < threshold, torch.zeros_like(reward), reward - threshold)
+    return reward.clamp(min=0.0, max=max_reward)
+
+
+def k1_feet_stumble(env, sensor_cfg: SceneEntityCfg) -> torch.Tensor:
+    contact_sensor: ContactSensor = env.scene.sensors[sensor_cfg.name]
+    horizontal_force = torch.norm(contact_sensor.data.net_forces_w[:, sensor_cfg.body_ids, :2], dim=-1)
+    vertical_force = torch.abs(contact_sensor.data.net_forces_w[:, sensor_cfg.body_ids, 2])
+    return torch.any(horizontal_force > 5.0 * vertical_force, dim=-1).float()
+
+
+def k1_feet_too_near_humanoid(
+    env,
+    threshold: float,
+    asset_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+) -> torch.Tensor:
+    asset: Articulation = env.scene[asset_cfg.name]
+    feet_pos = asset.data.body_pos_w[:, asset_cfg.body_ids, :]
+    distance = torch.norm(feet_pos[:, 0] - feet_pos[:, 1], dim=-1)
+    return (threshold - distance).clamp(min=0.0)

--- a/source/booster_train/booster_train/tasks/manager_based/locomotion/robots/__init__.py
+++ b/source/booster_train/booster_train/tasks/manager_based/locomotion/robots/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause

--- a/source/booster_train/booster_train/tasks/manager_based/locomotion/robots/k1/__init__.py
+++ b/source/booster_train/booster_train/tasks/manager_based/locomotion/robots/k1/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause

--- a/source/booster_train/booster_train/tasks/manager_based/locomotion/robots/k1/walk/__init__.py
+++ b/source/booster_train/booster_train/tasks/manager_based/locomotion/robots/k1/walk/__init__.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import gymnasium as gym
+
+
+gym.register(
+    id="Booster-K1-Locomotion-v0",
+    entry_point="isaaclab.envs:ManagerBasedRLEnv",
+    disable_env_checker=True,
+    kwargs={
+        "env_cfg_entry_point": f"{__name__}.env_cfg:FlatEnvCfg",
+        "rsl_rl_cfg_entry_point": f"{__name__}.ppo_cfg:PPORunnerCfg",
+    },
+)
+
+gym.register(
+    id="Booster-K1-Locomotion-v0-Play",
+    entry_point="isaaclab.envs:ManagerBasedRLEnv",
+    disable_env_checker=True,
+    kwargs={
+        "env_cfg_entry_point": f"{__name__}.env_cfg:PlayFlatEnvCfg",
+        "rsl_rl_cfg_entry_point": f"{__name__}.ppo_cfg:PPORunnerCfg",
+    },
+)

--- a/source/booster_train/booster_train/tasks/manager_based/locomotion/robots/k1/walk/env_cfg.py
+++ b/source/booster_train/booster_train/tasks/manager_based/locomotion/robots/k1/walk/env_cfg.py
@@ -1,0 +1,556 @@
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from __future__ import annotations
+
+from dataclasses import MISSING
+
+import isaaclab.sim as sim_utils
+from isaaclab.assets import ArticulationCfg, AssetBaseCfg
+from isaaclab.envs import ManagerBasedRLEnvCfg
+from isaaclab.managers import EventTermCfg as EventTerm
+from isaaclab.managers import ObservationGroupCfg as ObsGroup
+from isaaclab.managers import ObservationTermCfg as ObsTerm
+from isaaclab.managers import RewardTermCfg as RewTerm
+from isaaclab.managers import SceneEntityCfg
+from isaaclab.managers import TerminationTermCfg as DoneTerm
+from isaaclab.scene import InteractiveSceneCfg
+from isaaclab.sensors import ContactSensorCfg
+from isaaclab.terrains import TerrainImporterCfg
+from isaaclab.utils import configclass
+from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
+
+from booster_train.assets.robots.booster import BOOSTER_K1_CFG
+import booster_train.tasks.manager_based.locomotion.mdp as mdp
+
+
+K1_WALK_ACTION_SCALE = 0.25
+K1_WALK_OBS_DOF_VEL_SCALE = 0.1
+K1_WALK_OBSERVATION_HISTORY_LENGTH = 10
+K1_WALK_SINGLE_FRAME_OBSERVATION_DIM = 69
+K1_WALK_EXPORTED_OBSERVATION_DIM = 690
+
+K1_WALK_POLICY_JOINT_NAMES = [
+    "ALeft_Shoulder_Pitch",
+    "ARight_Shoulder_Pitch",
+    "Left_Hip_Pitch",
+    "Right_Hip_Pitch",
+    "Left_Shoulder_Roll",
+    "Right_Shoulder_Roll",
+    "Left_Hip_Roll",
+    "Right_Hip_Roll",
+    "Left_Elbow_Pitch",
+    "Right_Elbow_Pitch",
+    "Left_Hip_Yaw",
+    "Right_Hip_Yaw",
+    "Left_Elbow_Yaw",
+    "Right_Elbow_Yaw",
+    "Left_Knee_Pitch",
+    "Right_Knee_Pitch",
+    "Left_Ankle_Pitch",
+    "Right_Ankle_Pitch",
+    "Left_Ankle_Roll",
+    "Right_Ankle_Roll",
+]
+
+K1_REAL_JOINT_NAMES = [
+    "AAHead_yaw",
+    "Head_pitch",
+    "ALeft_Shoulder_Pitch",
+    "Left_Shoulder_Roll",
+    "Left_Elbow_Pitch",
+    "Left_Elbow_Yaw",
+    "ARight_Shoulder_Pitch",
+    "Right_Shoulder_Roll",
+    "Right_Elbow_Pitch",
+    "Right_Elbow_Yaw",
+    "Left_Hip_Pitch",
+    "Left_Hip_Roll",
+    "Left_Hip_Yaw",
+    "Left_Knee_Pitch",
+    "Left_Ankle_Pitch",
+    "Left_Ankle_Roll",
+    "Right_Hip_Pitch",
+    "Right_Hip_Roll",
+    "Right_Hip_Yaw",
+    "Right_Knee_Pitch",
+    "Right_Ankle_Pitch",
+    "Right_Ankle_Roll",
+]
+
+K1_WALK_DEFAULT_JOINT_POS = [
+    0.0,
+    0.0,
+    0.2,
+    -1.25,
+    0.0,
+    -0.5,
+    0.2,
+    1.25,
+    0.0,
+    0.5,
+    -0.15,
+    0.0,
+    0.0,
+    0.3,
+    -0.15,
+    0.0,
+    -0.15,
+    0.0,
+    0.0,
+    0.3,
+    -0.15,
+    0.0,
+]
+
+K1_WALK_DEFAULT_JOINT_POS_BY_NAME = dict(zip(K1_REAL_JOINT_NAMES, K1_WALK_DEFAULT_JOINT_POS))
+
+K1_WALK_FOOT_BODY_NAMES = ["left_foot_link", "right_foot_link"]
+K1_WALK_ARM_JOINT_NAMES = [
+    "ALeft_Shoulder_Pitch",
+    "ARight_Shoulder_Pitch",
+    "Left_Shoulder_Roll",
+    "Right_Shoulder_Roll",
+    "Left_Elbow_Pitch",
+    "Right_Elbow_Pitch",
+    "Left_Elbow_Yaw",
+    "Right_Elbow_Yaw",
+]
+K1_WALK_ARM_ACTION_INDICES = [
+    K1_WALK_POLICY_JOINT_NAMES.index(name) for name in K1_WALK_ARM_JOINT_NAMES
+]
+K1_WALK_LEG_JOINT_NAMES = [
+    ".*_Hip_Pitch",
+    ".*_Hip_Roll",
+    ".*_Hip_Yaw",
+    ".*_Knee_Pitch",
+    ".*_Ankle_Pitch",
+    ".*_Ankle_Roll",
+]
+
+
+@configclass
+class K1WalkSceneCfg(InteractiveSceneCfg):
+    """Configuration for the K1 flat locomotion scene."""
+
+    terrain = TerrainImporterCfg(
+        prim_path="/World/ground",
+        terrain_type="plane",
+        collision_group=-1,
+        physics_material=sim_utils.RigidBodyMaterialCfg(
+            friction_combine_mode="multiply",
+            restitution_combine_mode="multiply",
+            static_friction=1.0,
+            dynamic_friction=1.0,
+        ),
+        visual_material=sim_utils.MdlFileCfg(
+            mdl_path=f"{ISAAC_NUCLEUS_DIR}/Materials/Base/Architecture/Shingles_01.mdl",
+            project_uvw=True,
+        ),
+    )
+    robot: ArticulationCfg = MISSING
+    contact_forces = ContactSensorCfg(
+        prim_path="{ENV_REGEX_NS}/Robot/.*",
+        history_length=3,
+        track_air_time=True,
+        force_threshold=10.0,
+        debug_vis=False,
+    )
+    light = AssetBaseCfg(
+        prim_path="/World/light",
+        spawn=sim_utils.DistantLightCfg(color=(0.75, 0.75, 0.75), intensity=3000.0),
+    )
+    sky_light = AssetBaseCfg(
+        prim_path="/World/skyLight",
+        spawn=sim_utils.DomeLightCfg(color=(0.13, 0.13, 0.13), intensity=1000.0),
+    )
+
+
+@configclass
+class CommandsCfg:
+    """Command specifications for the MDP."""
+
+    base_velocity = mdp.UniformVelocityCommandCfg(
+        asset_name="robot",
+        resampling_time_range=(10.0, 10.0),
+        rel_standing_envs=0.2,
+        rel_heading_envs=0.0,
+        heading_command=False,
+        debug_vis=True,
+        ranges=mdp.UniformVelocityCommandCfg.Ranges(
+            lin_vel_x=(-1.0, 1.0),
+            lin_vel_y=(-1.0, 1.0),
+            ang_vel_z=(-1.0, 1.0),
+        ),
+    )
+
+
+@configclass
+class ActionsCfg:
+    """Action specifications for the MDP."""
+
+    joint_pos = mdp.JointPositionActionCfg(
+        asset_name="robot",
+        joint_names=K1_WALK_POLICY_JOINT_NAMES,
+        scale=K1_WALK_ACTION_SCALE,
+        use_default_offset=True,
+        preserve_order=True,
+    )
+
+
+@configclass
+class ObservationsCfg:
+    """Observation specifications for the MDP."""
+
+    @configclass
+    class PolicyCfg(ObsGroup):
+        deploy_locomotion_obs = ObsTerm(
+            func=mdp.k1_deploy_locomotion_observation,
+            params={
+                "command_name": "base_velocity",
+                "asset_cfg": SceneEntityCfg(
+                    "robot",
+                    joint_names=K1_WALK_POLICY_JOINT_NAMES,
+                    preserve_order=True,
+                ),
+                "obs_dof_vel_scale": K1_WALK_OBS_DOF_VEL_SCALE,
+            },
+            clip=(-100.0, 100.0),
+            history_length=K1_WALK_OBSERVATION_HISTORY_LENGTH,
+            flatten_history_dim=True,
+        )
+
+        def __post_init__(self):
+            self.enable_corruption = False
+            self.concatenate_terms = True
+
+    @configclass
+    class CriticCfg(ObsGroup):
+        legged_lab_critic_obs = ObsTerm(
+            func=mdp.k1_legged_lab_critic_observation,
+            params={
+                "command_name": "base_velocity",
+                "asset_cfg": SceneEntityCfg(
+                    "robot",
+                    joint_names=K1_WALK_POLICY_JOINT_NAMES,
+                    preserve_order=True,
+                ),
+                "sensor_cfg": SceneEntityCfg(
+                    "contact_forces",
+                    body_names=K1_WALK_FOOT_BODY_NAMES,
+                    preserve_order=True,
+                ),
+                "obs_dof_vel_scale": K1_WALK_OBS_DOF_VEL_SCALE,
+                "contact_threshold": 0.5,
+            },
+            clip=(-100.0, 100.0),
+            history_length=K1_WALK_OBSERVATION_HISTORY_LENGTH,
+            flatten_history_dim=True,
+        )
+
+        def __post_init__(self):
+            self.enable_corruption = False
+            self.concatenate_terms = True
+
+    policy: PolicyCfg = PolicyCfg()
+    critic: CriticCfg = CriticCfg()
+
+
+@configclass
+class EventCfg:
+    """Configuration for events."""
+
+    physics_material = EventTerm(
+        func=mdp.randomize_rigid_body_material,
+        mode="startup",
+        params={
+            "asset_cfg": SceneEntityCfg("robot", body_names=".*"),
+            "static_friction_range": (0.6, 1.0),
+            "dynamic_friction_range": (0.4, 0.8),
+            "restitution_range": (0.0, 0.005),
+            "num_buckets": 64,
+        },
+    )
+
+    add_base_mass = EventTerm(
+        func=mdp.randomize_rigid_body_mass,
+        mode="startup",
+        params={
+            "asset_cfg": SceneEntityCfg("robot", body_names="Trunk"),
+            "mass_distribution_params": (-5.0, 5.0),
+            "operation": "add",
+        },
+    )
+
+    reset_base = EventTerm(
+        func=mdp.reset_root_state_uniform,
+        mode="reset",
+        params={
+            "pose_range": {"x": (-0.5, 0.5), "y": (-0.5, 0.5), "yaw": (-3.14, 3.14)},
+            "velocity_range": {
+                "x": (-0.5, 0.5),
+                "y": (-0.5, 0.5),
+                "z": (-0.5, 0.5),
+                "roll": (-0.5, 0.5),
+                "pitch": (-0.5, 0.5),
+                "yaw": (-0.5, 0.5),
+            },
+        },
+    )
+
+    reset_robot_joints = EventTerm(
+        func=mdp.reset_joints_by_scale,
+        mode="reset",
+        params={
+            "position_range": (0.5, 1.5),
+            "velocity_range": (0.0, 0.0),
+        },
+    )
+
+    push_robot = EventTerm(
+        func=mdp.push_by_setting_velocity,
+        mode="interval",
+        interval_range_s=(10.0, 15.0),
+        params={"velocity_range": {"x": (-1.0, 1.0), "y": (-1.0, 1.0)}},
+    )
+
+
+@configclass
+class RewardsCfg:
+    """LeggedLab/T1-style reward terms for K1 deploy-compatible locomotion."""
+
+    track_lin_vel_xy_exp = RewTerm(
+        func=mdp.track_lin_vel_xy_yaw_frame_exp,
+        weight=1.0,
+        params={"command_name": "base_velocity", "std": 0.5},
+    )
+    track_ang_vel_z_exp = RewTerm(
+        func=mdp.track_ang_vel_z_world_exp,
+        weight=1.0,
+        params={"command_name": "base_velocity", "std": 0.5},
+    )
+    lin_vel_z_l2 = RewTerm(func=mdp.lin_vel_z_l2, weight=-1.0)
+    ang_vel_xy_l2 = RewTerm(func=mdp.ang_vel_xy_l2, weight=-0.05)
+    energy = RewTerm(
+        func=mdp.k1_joint_energy,
+        weight=-1.0e-3,
+        params={
+            "asset_cfg": SceneEntityCfg(
+                "robot",
+                joint_names=K1_WALK_POLICY_JOINT_NAMES,
+                preserve_order=True,
+            )
+        },
+    )
+    joint_torques_l2 = RewTerm(
+        func=mdp.k1_joint_torques_l2,
+        weight=-2.0e-6,
+        params={
+            "asset_cfg": SceneEntityCfg(
+                "robot",
+                joint_names=K1_WALK_POLICY_JOINT_NAMES,
+                preserve_order=True,
+            )
+        },
+    )
+    dof_acc_l2 = RewTerm(
+        func=mdp.joint_acc_l2,
+        weight=-1.25e-7,
+        params={
+            "asset_cfg": SceneEntityCfg(
+                "robot",
+                joint_names=K1_WALK_POLICY_JOINT_NAMES,
+                preserve_order=True,
+            )
+        },
+    )
+    action_rate_l2 = RewTerm(func=mdp.action_rate_l2, weight=-0.01)
+    arm_joint_deviation_l1 = RewTerm(
+        func=mdp.joint_deviation_l1,
+        weight=-0.2,
+        params={
+            "asset_cfg": SceneEntityCfg(
+                "robot",
+                joint_names=K1_WALK_ARM_JOINT_NAMES,
+                preserve_order=True,
+            )
+        },
+    )
+    arm_action_l2 = RewTerm(
+        func=mdp.action_l2_subset,
+        weight=-0.03,
+        params={"action_indices": K1_WALK_ARM_ACTION_INDICES},
+    )
+    arm_action_rate_l2 = RewTerm(
+        func=mdp.action_rate_l2_subset,
+        weight=-0.02,
+        params={"action_indices": K1_WALK_ARM_ACTION_INDICES},
+    )
+    flat_orientation_l2 = RewTerm(func=mdp.flat_orientation_l2, weight=-1.0)
+    termination_penalty = RewTerm(func=mdp.is_terminated, weight=-200.0)
+    feet_air_time = RewTerm(
+        func=mdp.feet_air_time_positive_biped,
+        weight=0.5,
+        params={
+            "sensor_cfg": SceneEntityCfg(
+                "contact_forces",
+                body_names=K1_WALK_FOOT_BODY_NAMES,
+                preserve_order=True,
+            ),
+            "command_name": "base_velocity",
+            "threshold": 0.4,
+        },
+    )
+    feet_slide = RewTerm(
+        func=mdp.feet_slide,
+        weight=-0.25,
+        params={
+            "sensor_cfg": SceneEntityCfg(
+                "contact_forces",
+                body_names=K1_WALK_FOOT_BODY_NAMES,
+                preserve_order=True,
+            ),
+            "asset_cfg": SceneEntityCfg(
+                "robot",
+                body_names=K1_WALK_FOOT_BODY_NAMES,
+                preserve_order=True,
+            ),
+        },
+    )
+    feet_force = RewTerm(
+        func=mdp.k1_body_force,
+        weight=-3.0e-3,
+        params={
+            "sensor_cfg": SceneEntityCfg(
+                "contact_forces",
+                body_names=K1_WALK_FOOT_BODY_NAMES,
+                preserve_order=True,
+            ),
+            "threshold": 500.0,
+            "max_reward": 400.0,
+        },
+    )
+    feet_too_near = RewTerm(
+        func=mdp.k1_feet_too_near_humanoid,
+        weight=-2.0,
+        params={
+            "threshold": 0.2,
+            "asset_cfg": SceneEntityCfg(
+                "robot",
+                body_names=K1_WALK_FOOT_BODY_NAMES,
+                preserve_order=True,
+            ),
+        },
+    )
+    feet_stumble = RewTerm(
+        func=mdp.k1_feet_stumble,
+        weight=-2.0,
+        params={
+            "sensor_cfg": SceneEntityCfg(
+                "contact_forces",
+                body_names=K1_WALK_FOOT_BODY_NAMES,
+                preserve_order=True,
+            )
+        },
+    )
+    dof_pos_limits = RewTerm(
+        func=mdp.joint_pos_limits,
+        weight=-2.0,
+        params={
+            "asset_cfg": SceneEntityCfg(
+                "robot",
+                joint_names=K1_WALK_POLICY_JOINT_NAMES,
+                preserve_order=True,
+            )
+        },
+    )
+    undesired_contacts = RewTerm(
+        func=mdp.undesired_contacts,
+        weight=-1.0,
+        params={
+            "sensor_cfg": SceneEntityCfg(
+                "contact_forces",
+                body_names=[r"^(?!left_foot_link$)(?!right_foot_link$).+$"],
+            ),
+            "threshold": 1.0,
+        },
+    )
+
+
+@configclass
+class TerminationsCfg:
+    """Termination terms for the MDP."""
+
+    time_out = DoneTerm(func=mdp.time_out, time_out=True)
+    base_contact = DoneTerm(
+        func=mdp.illegal_contact,
+        params={"sensor_cfg": SceneEntityCfg("contact_forces", body_names="Trunk"), "threshold": 1.0},
+    )
+    bad_orientation = DoneTerm(func=mdp.bad_orientation, params={"limit_angle": 0.8})
+
+
+@configclass
+class CurriculumCfg:
+    """Curriculum terms for the MDP."""
+
+    pass
+
+
+@configclass
+class FlatEnvCfg(ManagerBasedRLEnvCfg):
+    """Flat-terrain K1 velocity-tracking environment."""
+
+    scene: K1WalkSceneCfg = K1WalkSceneCfg(num_envs=4096, env_spacing=2.5)
+    observations: ObservationsCfg = ObservationsCfg()
+    actions: ActionsCfg = ActionsCfg()
+    commands: CommandsCfg = CommandsCfg()
+    rewards: RewardsCfg = RewardsCfg()
+    terminations: TerminationsCfg = TerminationsCfg()
+    events: EventCfg = EventCfg()
+    curriculum: CurriculumCfg = CurriculumCfg()
+
+    action_scale = K1_WALK_ACTION_SCALE
+    action_joint_names = K1_WALK_POLICY_JOINT_NAMES
+    observation_history_length = K1_WALK_OBSERVATION_HISTORY_LENGTH
+    single_frame_observation_dim = K1_WALK_SINGLE_FRAME_OBSERVATION_DIM
+    exported_observation_dim = K1_WALK_EXPORTED_OBSERVATION_DIM
+
+    def __post_init__(self):
+        """Post initialization."""
+        self.scene.robot = BOOSTER_K1_CFG.replace(
+            prim_path="{ENV_REGEX_NS}/Robot",
+            init_state=ArticulationCfg.InitialStateCfg(
+                pos=(0.0, 0.0, 0.57),
+                joint_pos=K1_WALK_DEFAULT_JOINT_POS_BY_NAME,
+                joint_vel={".*": 0.0},
+            ),
+        )
+
+        self.decimation = 4
+        self.episode_length_s = 20.0
+        self.sim.dt = 0.005
+        self.sim.render_interval = self.decimation
+        self.sim.physics_material = self.scene.terrain.physics_material
+        self.sim.physx.gpu_max_rigid_patch_count = 10 * 2**15
+        self.viewer.origin_type = "world"
+        self.viewer.eye = (3.0, -4.0, 2.0)
+        self.viewer.lookat = (0.0, 0.0, 1.0)
+
+        if self.scene.contact_forces is not None:
+            self.scene.contact_forces.update_period = self.sim.dt
+
+
+@configclass
+class PlayFlatEnvCfg(FlatEnvCfg):
+    """Reduced K1 locomotion environment for play/export."""
+
+    def __post_init__(self):
+        super().__post_init__()
+
+        self.scene.num_envs = 50
+        self.scene.env_spacing = 2.5
+        self.events.physics_material = None
+        self.events.add_base_mass = None
+        self.events.push_robot = None

--- a/source/booster_train/booster_train/tasks/manager_based/locomotion/robots/k1/walk/env_cfg.py
+++ b/source/booster_train/booster_train/tasks/manager_based/locomotion/robots/k1/walk/env_cfg.py
@@ -228,8 +228,8 @@ class ObservationsCfg:
 
     @configclass
     class CriticCfg(ObsGroup):
-        legged_lab_critic_obs = ObsTerm(
-            func=mdp.k1_legged_lab_critic_observation,
+        privileged_locomotion_obs = ObsTerm(
+            func=mdp.k1_privileged_locomotion_observation,
             params={
                 "command_name": "base_velocity",
                 "asset_cfg": SceneEntityCfg(
@@ -319,7 +319,7 @@ class EventCfg:
 
 @configclass
 class RewardsCfg:
-    """LeggedLab/T1-style reward terms for K1 deploy-compatible locomotion."""
+    """Reward terms for K1 deploy-compatible locomotion."""
 
     track_lin_vel_xy_exp = RewTerm(
         func=mdp.track_lin_vel_xy_yaw_frame_exp,
@@ -553,4 +553,6 @@ class PlayFlatEnvCfg(FlatEnvCfg):
         self.scene.env_spacing = 2.5
         self.events.physics_material = None
         self.events.add_base_mass = None
+        self.events.reset_base = None
+        self.events.reset_robot_joints = None
         self.events.push_robot = None

--- a/source/booster_train/booster_train/tasks/manager_based/locomotion/robots/k1/walk/ppo_cfg.py
+++ b/source/booster_train/booster_train/tasks/manager_based/locomotion/robots/k1/walk/ppo_cfg.py
@@ -9,7 +9,7 @@ from isaaclab_rl.rsl_rl import RslRlOnPolicyRunnerCfg, RslRlPpoActorCriticCfg, R
 
 @configclass
 class PPORunnerCfg(RslRlOnPolicyRunnerCfg):
-    """LeggedLab/T1-style PPO recipe for K1 deploy-compatible locomotion."""
+    """PPO runner configuration for K1 deploy-compatible locomotion."""
 
     seed = 42
     num_steps_per_env = 24

--- a/source/booster_train/booster_train/tasks/manager_based/locomotion/robots/k1/walk/ppo_cfg.py
+++ b/source/booster_train/booster_train/tasks/manager_based/locomotion/robots/k1/walk/ppo_cfg.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from isaaclab.utils import configclass
+from isaaclab_rl.rsl_rl import RslRlOnPolicyRunnerCfg, RslRlPpoActorCriticCfg, RslRlPpoAlgorithmCfg
+
+
+@configclass
+class PPORunnerCfg(RslRlOnPolicyRunnerCfg):
+    """LeggedLab/T1-style PPO recipe for K1 deploy-compatible locomotion."""
+
+    seed = 42
+    num_steps_per_env = 24
+    max_iterations = 50000
+    save_interval = 100
+    experiment_name = "k1_locomotion"
+    empirical_normalization = True
+    clip_actions = None
+    policy = RslRlPpoActorCriticCfg(
+        init_noise_std=1.0,
+        actor_hidden_dims=[512, 256, 128],
+        critic_hidden_dims=[512, 256, 128],
+        activation="elu",
+    )
+    algorithm = RslRlPpoAlgorithmCfg(
+        value_loss_coef=1.0,
+        use_clipped_value_loss=True,
+        clip_param=0.2,
+        entropy_coef=0.005,
+        num_learning_epochs=5,
+        num_mini_batches=4,
+        learning_rate=1.0e-3,
+        schedule="adaptive",
+        gamma=0.99,
+        lam=0.95,
+        desired_kl=0.01,
+        max_grad_norm=1.0,
+    )


### PR DESCRIPTION
## Summary

Adds the minimal K1 locomotion manager-based task port needed for training and play/evaluation:

- `Booster-K1-Locomotion-v0`
- `Booster-K1-Locomotion-v0-Play`

This PR intentionally excludes later validation variants, Unitree velocity experiments, docs, helper scripts, and BeyondMimic changes so the merge scope stays focused on the base K1 locomotion task.

## What Changed

- Adds the `locomotion` task package and K1 `walk` registration.
- Adds K1-specific locomotion observation and reward helpers.
- Adds the flat K1 velocity-tracking environment config and PPO runner config.
- Keeps the Play config minimal by disabling startup/reset/push randomization for play/export.

## Validation

- `../env_isaaclab/bin/python scripts/list_envs.py`
- AppLauncher registry probe confirmed `Booster-K1-Locomotion-v0` and `Booster-K1-Locomotion-v0-Play` are registered, with no `UnitreeVelocity` or `IdealFlat` locomotion tasks in this PR branch.
- AppLauncher `gym.make -> reset -> zero-action step` succeeded for `Booster-K1-Locomotion-v0` with `num_envs=2`, action dim `20`, reward shape `(2,)`.
- AppLauncher `gym.make -> reset -> zero-action step` succeeded for `Booster-K1-Locomotion-v0-Play` with `num_envs=2`, action dim `20`, reward shape `(2,)`.
- `../env_isaaclab/bin/python scripts/rsl_rl/play.py --task Booster-K1-Locomotion-v0-Play --checkpoint logs/rsl_rl/k1_locomotion/2026-05-21_02-09-01/model_16900.pt --num_envs 1 --headless --device cuda:0`
